### PR TITLE
Strip out comments from package and import matcher.

### DIFF
--- a/src/main/java/de/skuzzle/enforcer/restrictimports/impl/ImportMatcherImpl.java
+++ b/src/main/java/de/skuzzle/enforcer/restrictimports/impl/ImportMatcherImpl.java
@@ -107,7 +107,12 @@ class ImportMatcherImpl implements ImportMatcher {
     }
 
     private static boolean is(String compare, String line) {
-        return line.startsWith(compare) && line.endsWith(";");
+        String stripped = line.replaceAll("\\/\\*.*?\\*\\/", "");
+        int inlineCommentIndex = stripped.indexOf("//");
+        if (inlineCommentIndex >= 0) {
+            stripped = stripped.substring(0, inlineCommentIndex);
+        }
+        return stripped.startsWith(compare) && stripped.endsWith(";");
     }
 
     private static boolean isPackage(String line) {

--- a/src/test/java/de/skuzzle/enforcer/restrictimports/impl/ImportMatcherImplTest.java
+++ b/src/test/java/de/skuzzle/enforcer/restrictimports/impl/ImportMatcherImplTest.java
@@ -125,6 +125,28 @@ public class ImportMatcherImplTest {
     }
 
     @Test
+    public void testExcludeInstrumentedFile() throws Exception {
+        when(this.mockLineSupplier.lines(this.path)).thenReturn(ImmutableList.of(
+                "/*Instrumented*/package de.skuzzle.test;",
+                "",
+                "import de.skuzzle.sample.Test;",
+                "import   foo.bar.xyz;",
+                "import de.skuzzle.sample.Test2;",
+                "import de.foo.bar.Test").stream());
+
+        final BannedImportGroup group = new BannedImportGroup(
+                Arrays.asList(PackagePattern.parse("**")),
+                PackagePattern.parseAll(ImmutableList.of("foo")),
+                ImmutableList.of(),
+                PackagePattern.parseAll(ImmutableList.of("de.skuzzle.test.File")),
+                "message");
+
+        final Stream<Match> matches = this.subject.matchFile(this.path, group);
+
+        assertFalse(matches.iterator().hasNext());
+    }
+
+    @Test
     public void testExcludeWholeFile() throws Exception {
         final Stream<Match> matches = this.subject.matchFile(this.path,
                 group(Arrays.asList("de.foo.bar"),

--- a/src/test/java/de/skuzzle/enforcer/restrictimports/impl/ImportMatcherImplTest.java
+++ b/src/test/java/de/skuzzle/enforcer/restrictimports/impl/ImportMatcherImplTest.java
@@ -49,6 +49,9 @@ public class ImportMatcherImplTest {
                 "import de.skuzzle.sample.Test;",
                 "import   foo.bar.xyz;",
                 "import de.skuzzle.sample.Test2;",
+                "import de.skuzzle.sample.Test3;//inline comment",
+                "/*block comment */import de.skuzzle.sample.Test4;",
+                "/** Weird block comment ///**//**/import de.skuzzle.sample.Test5;//de.skuzzle.sample.TestIgnored",
                 "import de.foo.bar.Test").stream());
     }
 
@@ -83,7 +86,7 @@ public class ImportMatcherImplTest {
                         banned, ImmutableList.of()))
                 .collect(Collectors.toList());
 
-        assertEquals(2, matches.size());
+        assertEquals(5, matches.size());
         final Match match1 = matches.get(0);
         assertEquals("de.skuzzle.sample.Test", match1.getMatchedString());
         assertEquals(3, match1.getImportLine());
@@ -93,21 +96,48 @@ public class ImportMatcherImplTest {
         assertEquals(5, match2.getImportLine());
         assertEquals("de.skuzzle.sample.Test2", match2.getMatchedString());
         assertEquals("path/to/File.java", match2.getSourceFile());
+
+        final Match match3 = matches.get(2);
+        assertEquals(6, match3.getImportLine());
+        assertEquals("de.skuzzle.sample.Test3", match3.getMatchedString());
+        assertEquals("path/to/File.java", match3.getSourceFile());
+
+        final Match match4 = matches.get(3);
+        assertEquals(7, match4.getImportLine());
+        assertEquals("de.skuzzle.sample.Test4", match4.getMatchedString());
+        assertEquals("path/to/File.java", match4.getSourceFile());
+
+        final Match match5 = matches.get(4);
+        assertEquals(8, match5.getImportLine());
+        assertEquals("de.skuzzle.sample.Test5", match5.getMatchedString());
+        assertEquals("path/to/File.java", match5.getSourceFile());
     }
 
     @Test
     public void testMatchWithInclude() throws Exception {
         final List<String> banned = ImmutableList.of("de.skuzzle.sample.*");
-        final List<String> include = ImmutableList.of("de.skuzzle.sample.Test2");
+        final List<String> include = ImmutableList.of(
+                "de.skuzzle.sample.Test2",
+                "de.skuzzle.sample.Test4");
         final List<Match> matches = this.subject
                 .matchFile(this.path, group(Arrays.asList("**"), banned, include))
                 .collect(Collectors.toList());
 
-        assertEquals(1, matches.size());
+        assertEquals(3, matches.size());
         final Match match1 = matches.get(0);
         assertEquals("de.skuzzle.sample.Test", match1.getMatchedString());
         assertEquals(3, match1.getImportLine());
         assertEquals("path/to/File.java", match1.getSourceFile());
+
+        final Match match2 = matches.get(1);
+        assertEquals(6, match2.getImportLine());
+        assertEquals("de.skuzzle.sample.Test3", match2.getMatchedString());
+        assertEquals("path/to/File.java", match2.getSourceFile());
+
+        final Match match3 = matches.get(2);
+        assertEquals(8, match3.getImportLine());
+        assertEquals("de.skuzzle.sample.Test5", match3.getMatchedString());
+        assertEquals("path/to/File.java", match3.getSourceFile());
     }
 
     @Test


### PR DESCRIPTION
Some instrumentation libraries are putting a top line comment saying
that this class was instrumented that messes with class matching.