### PR TITLE
Bump guava library to get the fix for java.lang.NoSuchMethodError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>27.0-jre</version>
+			<version>27.1-jre</version>
 		</dependency>
 
 		<!-- Maven -->


### PR DESCRIPTION
Update guava library to get the fix for: 

An API incompatibility was encountered while executing org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M1:enforce: java.lang.NoSuchMethodError: com.google.common.base.Preconditions.checkState(ZLjava/lang/String;Ljava/lang/Object;)V