### PR TITLE
Wildcard pattern must match at lease one part

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,11 @@
 [![Maven Central](https://img.shields.io/static/v1?label=MavenCentral&message=2.2.1-SNAPSHOT&color=blue)](https://search.maven.org/artifact/de.skuzzle.enforcer/restrict-imports-enforcer-rule/2.2.1-SNAPSHOT/jar) [![JavaDoc](https://img.shields.io/static/v1?label=JavaDoc&message=2.2.1-SNAPSHOT&color=orange)](http://www.javadoc.io/doc/de.skuzzle.enforcer/restrict-imports-enforcer-rule/2.2.1-SNAPSHOT)
 
-### Features
-* [#60](https://github.com/skuzzle/restrict-imports-enforcer-rule/issues/60) Fall back to _line-by-line_ parsing if _full-compilation-unit_ parsing failed.
+### Bug fixes
+* [#73](https://github.com/skuzzle/restrict-imports-enforcer-rule/issues/73) Classloader issues while locating LanguageSupport instances
+* [#76](https://github.com/skuzzle/restrict-imports-enforcer-rule/issues/76) `**` wildcard must match at least a single package part
+
+### Misc
+* Updated various dependencies
 
 
 

--- a/readme/RELEASE_NOTES.md
+++ b/readme/RELEASE_NOTES.md
@@ -1,7 +1,8 @@
 [![Maven Central](https://img.shields.io/static/v1?label=MavenCentral&message=${project.version}&color=blue)](https://search.maven.org/artifact/${project.groupId}/${project.artifactId}/${project.version}/jar) [![JavaDoc](https://img.shields.io/static/v1?label=JavaDoc&message=${project.version}&color=orange)](http://www.javadoc.io/doc/${project.groupId}/${project.artifactId}/${project.version})
 
 ### Bug fixes
-* [#73](https://github.com/skuzzle/restrict-imports-enforcer-rule/issues/73) Classloader issues while locating LanguageSupport instances #73
+* [#73](https://github.com/skuzzle/restrict-imports-enforcer-rule/issues/73) Classloader issues while locating LanguageSupport instances
+* [#76](https://github.com/skuzzle/restrict-imports-enforcer-rule/issues/76) `**` wildcard must match at least a single package part
 
 ### Misc
 * Updated various dependencies

--- a/src/main/java/de/skuzzle/enforcer/restrictimports/analyze/PackagePattern.java
+++ b/src/main/java/de/skuzzle/enforcer/restrictimports/analyze/PackagePattern.java
@@ -163,6 +163,13 @@ public final class PackagePattern implements Comparable<PackagePattern> {
 
             if ("**".equals(patternPart)) {
                 if (patternIndex + 1 < patternParts.length) {
+
+                    // See #76
+                    // https://github.com/skuzzle/restrict-imports-enforcer-rule/issues/76
+                    // ** is supposed to match at least one package. So we eagerly skip
+                    // one package
+                    matchIndex++;
+
                     final String nextPatternPart = patternParts[patternIndex + 1];
                     while (matchIndex < matchParts.length
                             && !matchParts(nextPatternPart, matchParts[matchIndex])) {

--- a/src/test/java/de/skuzzle/enforcer/restrictimports/analyze/PackagePatternTest.java
+++ b/src/test/java/de/skuzzle/enforcer/restrictimports/analyze/PackagePatternTest.java
@@ -10,6 +10,14 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 public class PackagePatternTest {
 
     @Test
+    void testMatchWildcardPrefix() {
+        // See #76
+        // https://github.com/skuzzle/restrict-imports-enforcer-rule/issues/76
+        assertThat(PackagePattern.parse("**.com.google.common.annotations.VisibleForTesting")
+                .matches("com.couchbase.client.core.deps.com.google.common.annotations.VisibleForTesting")).isTrue();
+    }
+
+    @Test
     void testMatchLiteralAsterisk() {
         final PackagePattern pattern = PackagePattern.parse("java.util.'*'");
         assertThat(pattern.matches("java.util.*")).isTrue();


### PR DESCRIPTION
Prior to this change it was possible that the wildcard matched no part if the next part in the pattern after the wildcard would match the next part in the package we compare against.

Fixes #76 