### PR TITLE
Explicit url and scm details to fix repo detection by renovatebot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,9 @@
     <packaging>jar</packaging>
     <name>Restrict Imports Enforcer Rule</name>
     <description>Bans imports of specified classes/packages</description>
-    <url>https://github.com/skuzzle/${github.name}</url>
+    <url>https://github.com/skuzzle/restrict-imports-enforcer-rule</url>
     <scm>
-        <developerConnection>scm:git:https://github.com/skuzzle/${github.name}.git</developerConnection>
+        <developerConnection>scm:git:https://github.com/skuzzle/restrict-imports-enforcer-rule.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
Purpose: I use renovatebot to monitor dependencies and now it points me to parent instead of this repo.

![image](https://github.com/skuzzle/restrict-imports-enforcer-rule/assets/749858/5df4ba63-d037-4fc5-89e5-bda3d5c8649d)

Expected: link to https://github.com/skuzzle/restrict-imports-enforcer-rule

Actual: https://github.com/skuzzle-parent