### PR TITLE
Speed up rebuilds by caching Maven IT tasks (1m27s → 11.5s)

### DIFF
--- a/build-logic/conventions/src/main/kotlin/build-logic.publishing-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/build-logic.publishing-conventions.gradle.kts
@@ -9,12 +9,12 @@ plugins {
 
 tasks.withType<Jar>().configureEach {
     manifest {
+        // Intentionally no "Created-By" attribute — the previous value derived from
+        // System.getProperty("java.version"/"java.vendor"/"java.vm.version") varied
+        // across JVMs and would cause cache misses for any downstream tasks that
+        // fingerprint the JAR's manifest, were Jar tasks ever opted into the build
+        // cache.
         attributes(
-            "Created-By" to "${System.getProperty("java.version")} (${System.getProperty("java.vendor")} ${
-                System.getProperty(
-                    "java.vm.version"
-                )
-            })",
             "Specification-Title" to project.name,
             "Specification-Version" to (project.version as String).substringBefore('-'),
             "Implementation-Title" to project.name,

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -52,9 +52,24 @@ val funcTestTasks = crossVersionTests
 
             val outputDir = mavenExecTask.name
             inputs.files(layout.projectDirectory.dir("src/it/maven"))
+                .withPropertyName("mavenIntegrationTestSources")
+                .withPathSensitivity(PathSensitivity.RELATIVE)
             inputs.files(layout.projectDirectory.file("invoker-settings.xml"))
+                .withPropertyName("invokerSettings")
+                .withPathSensitivity(PathSensitivity.RELATIVE)
             inputs.files(layout.projectDirectory.file("pom.xml"))
+                .withPropertyName("mavenItPom")
+                .withPathSensitivity(PathSensitivity.RELATIVE)
             outputs.dir(layout.buildDirectory.file(outputDir))
+
+            // Opt this task into the build cache. The MavenExec task type from the
+            // 'com.github.dkorotych.gradle-maven-exec' plugin is not annotated
+            // @CacheableTask, so Gradle treats it as not-worth-caching by default.
+            // All inputs above use RELATIVE path sensitivity, and mavenDir/define
+            // are already content-tracked by the plugin, so caching is safe for
+            // same-machine rebuilds. Cross-machine cache hits may still miss due
+            // to absolute paths baked into the Maven define map.
+            outputs.cacheIf("inputs fully tracked with relative path sensitivity") { true }
 
             mavenDir = maven.mavenHome(mavenVersion)
             goals(setOf("verify"))


### PR DESCRIPTION
## Summary

Run of the Gradle Build Caching Optimizer skill on the current `develop` HEAD surfaced one dominant source of wasted time and one latent reproducibility issue. Both are addressed here.

- **Enable build cache for 4 `funcTestMaven_*_enforcer_*` MavenExec tasks.** The `com.github.dkorotych.gradle-maven-exec` plugin's task type isn't annotated `@CacheableTask`, so Gradle re-executed these on every build — ~78s wasted per rebuild even when inputs were unchanged. Opted in via `outputs.cacheIf { true }` and declared `PathSensitivity.RELATIVE` on the three project-relative input groups (`src/it/maven`, `invoker-settings.xml`, `pom.xml`). `mavenDir` and absolute paths inside the Maven `-D define` map still use `ABSOLUTE_PATH` normalization, so cross-machine cache hits may still miss — but same-machine rebuilds now hit cleanly.
- **Drop the volatile `Created-By` Jar manifest attribute.** It interpolated `System.getProperty("java.version"/"java.vendor"/"java.vm.version")`, which vary across JVMs. Since default `Jar` tasks aren't cached today this caused no current cache impact, but it made the JAR manifest non-reproducible across different developer and CI JVMs and would have caused VOLATILE cache misses if Jar caching is ever enabled. Removing the attribute is the simplest preventive fix.

## Validation

Ran `clean build --build-cache` twice from the same checkout to measure rebuild performance:

| Metric | Before (baseline 2nd build) | After (2nd build) | Change |
|---|---|---|---|
| Build time | 1m 27s | **11.5s** | **−87%** |
| Cache hit rate | 74.0% | **93.9%** | +19.9 pp |
| Local cache savings | 97.2s | **170.2s** | +75% |

## Investigation Notes

Build Validation Scripts experiments 2 (same location) and 3 (different location) classified all 283 tasks: **0 VOLATILE, 0 NON_RELOCATABLE, 0 WORKSPACE_POLLUTION**. All 39 cacheable tasks cached correctly in both experiments — the build was already in very good shape. The 244 "not cacheable" tasks are mostly Gradle's intentional defaults (`Jar`, `PublishToMavenRepository`, `ProcessResources`, `Delete`, `Sync`). The one outlier was the third-party `MavenExec` task type above.

Two lower-impact findings were investigated but **not** fixed here:
- `VerifyPublicationTask` (build-logic) is not `@CacheableTask`, and its `artifacts` list is `@Internal`. Making it cacheable requires refactoring `PublishedArtifactRule`/`JarContainsRule`/`FileMatchesRule` to eliminate Kotlin lambda closures (`(String) -> Boolean`, `Action<JarContainsRule>`) which can't be serialized as `@Input`. Only ~112ms/build wasted — not worth the DSL churn.
- `CopyAndFilterReadmeTask` declares `sourceDir`/`targetDir` as `@Internal` and writes to `project.rootDir` (workspace pollution pattern). But it only runs from `prepareRelease`, never from `build`, so it's not on any critical path today.

## Test plan

- [ ] CI green on this branch (`build` task, which includes the Maven invoker integration tests)
- [ ] Verify a second `./gradlew build --build-cache` on a developer machine completes in ~10-15s (cache hit on `funcTestMaven_*`)
- [ ] Confirm published JAR manifests still carry the intended `Specification-*` / `Implementation-*` attributes and no longer carry `Created-By`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)