### PR TITLE
Do not promote staging repositories on release dry run

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,14 @@ nexusPublishing.repositories {
     }
 }
 
-tasks.prepareRelease.configure { dependsOn(tasks.closeAndReleaseStagingRepositories) }
+tasks.prepareRelease.configure {
+    val dryRunEnabled = release.dryRun.get()
+    if (dryRunEnabled) {
+        logger.lifecycle("Not promoting the staging repository because release dry run is enabled")
+    } else {
+        dependsOn(tasks.closeAndReleaseStagingRepositories)
+    }
+}
 
 fun TaskContainer.connectIncludedBuildTasks(
     includedBuildName: String,

--- a/restrict-imports-enforcer-rule/restrict-imports-enforcer-rule.gradle.kts
+++ b/restrict-imports-enforcer-rule/restrict-imports-enforcer-rule.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("build-logic.published-java-component")
-    id("build-logic.release-lifecycle")
 }
 
 description = "Restrict Imports Enforcer Rule"
@@ -61,5 +60,3 @@ verifyPublication {
         }
     }
 }
-
-tasks.prepareRelease.configure { dependsOn(tasks.publishToSonatype) }


### PR DESCRIPTION
## Problem

A release run with `RELEASE_DRY_RUN=true` published artifacts to Maven Central.

The flag itself propagates fine — git pushes were skipped, no tag was created, the GitHub release was a dry run, and `publishPlugins` went validate-only. But `prepareRelease` depended on `closeAndReleaseStagingRepositories` unconditionally (`build.gradle.kts:24`), and `prepareRelease` is the first task the release pipeline runs. So the dry run filled a staging repository and then closed and released it, promoting the artifacts to Central irrevocably.

This was never guarded. `87e049a` guarded the Gradle Plugin Portal publish for dry runs back in 2024, because that one goes live on upload — the Sonatype publish needed no guard at the time, since it only filled a staging repository that was then promoted by hand. `6f32ff5` automated the promotion (the day after `661dce2` moved to the OSSRH staging API endpoint, which retired the manual step) without carrying the dry-run guard across.

## Change

Guard the promotion only, mirroring the existing `publishPlugins` guard in `restrict-imports-gradle-plugin.gradle.kts`.

Publishing to the staging repository stays unguarded on purpose — it is what makes a dry run worth running, since it exercises signing, POM validation and the staging API. It is also safe: `closeAndReleaseSonatypeStagingRepository` takes `stagingRepositoryId` as a task input, populated by `initializeSonatypeStagingRepository` in the same build, so a release run can only ever promote the repository it just created. Staging repositories left behind by a dry run cannot be picked up by a later real release.

The message uses `logger.lifecycle` rather than the sibling guard's `logger.info`, since it is the only evidence in a dry-run log that promotion was skipped and should not need `-i` to show up.

Also drops a redundant `prepareRelease dependsOn publishToSonatype` from `restrict-imports-enforcer-rule.gradle.kts` — `build-logic.publishing-conventions` already wires that up for every project it applies to, and both lines resolve to the same two tasks in the same project. With it gone, `id("build-logic.release-lifecycle")` in that file's plugins block is dead too: it was only there to expose the type-safe `prepareRelease` accessor, and `publishing-conventions` applies the plugin regardless. Unrelated to the dry-run fix, hence a separate commit.

## Verification

`prepareRelease --dry-run`, comparing the task graph:

| | without `-PreleaseDryRun` | with `-PreleaseDryRun=true` |
|---|---|---|
| `initializeSonatypeStagingRepository` | in graph | in graph |
| `publishToSonatype` (both modules) | in graph | in graph |
| `closeSonatypeStagingRepository` | in graph | **absent** |
| `releaseSonatypeStagingRepository` | in graph | **absent** |
| `closeAndReleaseStagingRepositories` | in graph | **absent** |

The lifecycle message prints in the dry-run graph. `restrict-imports-enforcer-rule:publishToSonatype` remains in both graphs after the removal above, confirming it was redundant. `quickCheck` passes.

## Note

The artifacts already published by the affected run cannot be recalled — Maven Central is immutable. Remediation there is a follow-up release, not a deletion.
