### PR TITLE
Fix Gradle plugin coordinates in the legacy buildscript snippet

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,7 +38,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath("de.skuzzle.enforcer:restrict-imports-gradle-plugin:3.0.1")
+    classpath("de.skuzzle.restrictimports:restrict-imports-gradle-plugin:3.0.1")
   }
 }
 

--- a/readme/RELEASE_NOTES.md
+++ b/readme/RELEASE_NOTES.md
@@ -38,7 +38,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath("de.skuzzle.enforcer:restrict-imports-gradle-plugin:@project.version@")
+    classpath("de.skuzzle.restrictimports:restrict-imports-gradle-plugin:@project.version@")
   }
 }
 


### PR DESCRIPTION
The "Gradle Legacy" snippet in the release notes points at the wrong group:

```groovy
classpath("de.skuzzle.enforcer:restrict-imports-gradle-plugin:<version>")
```

`de.skuzzle.enforcer` is the enforcer rule's group. The Gradle plugin is published under `de.skuzzle.restrictimports` (`restrict-imports-gradle-plugin.gradle.kts:10`), so the advertised coordinates have never resolved.

Checked against Maven Central:

| Coordinates | 2.6.1 | 3.0.0 | 3.0.1 |
|---|---|---|---|
| `de.skuzzle.enforcer:restrict-imports-gradle-plugin` | 404 | 404 | 404 |
| `de.skuzzle.restrictimports:restrict-imports-gradle-plugin` | 200 | 200 | 200 |

So this has been broken for at least three releases — anyone following the legacy buildscript instructions got an unresolvable dependency. The plugin DSL snippet above it is unaffected, since it resolves the plugin id from the Plugin Portal rather than these coordinates.

No token exists for the plugin's group, so the fix writes it out, the same way the line above already hardcodes the plugin id.

The generated copy in the root directory is fixed alongside the template. It regenerates from the template at the next release anyway, but fixing it now means the notes in the repo are correct in the meantime rather than only after 3.0.2. The pushed `v3.0.1` tag is deliberately untouched. The 3.0.1 GitHub release is still a draft and its body was corrected separately, so it will carry the right coordinates when it is published.
