### PR TITLE
Fix the broken coverage upload and count every test suite

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
         stage('Unit-tests') {
             steps {
                 withGradle {
-                    sh './gradlew test coverallsJacoco'
+                    sh './gradlew test'
                 }
             }
         }
@@ -52,6 +52,14 @@ pipeline {
             steps {
                 withGradle {
                     sh './gradlew functionalTest'
+                }
+            }
+        }
+        stage('Coverage') {
+            steps {
+                withGradle {
+                    // Aggregates the coverage of both test stages, so it has to run after them.
+                    sh './gradlew coverallsJacoco'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
         stage('Unit-tests') {
             steps {
                 withGradle {
-                    sh './gradlew test coveralls'
+                    sh './gradlew test coverallsJacoco'
                 }
             }
         }

--- a/JenkinsfileRelease
+++ b/JenkinsfileRelease
@@ -72,7 +72,9 @@ pipeline {
         stage('Unit-tests') {
             steps {
                 withGradle {
-                    sh './gradlew test coveralls'
+                    // No coverage upload here: this pipeline has no COVERALLS_REPO_TOKEN, and the
+                    // branch build already reports coverage for every commit it releases.
+                    sh './gradlew test'
                 }
             }
         }

--- a/build-logic/jacoco-testkit/build.gradle.kts
+++ b/build-logic/jacoco-testkit/build.gradle.kts
@@ -1,0 +1,22 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    implementation(kotlin("gradle-plugin"))
+}
+
+tasks {
+    withType<JavaCompile>().configureEach {
+        options.release = 17
+    }
+    withType<KotlinCompile>().configureEach {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_17
+            allWarningsAsErrors = true
+        }
+    }
+}

--- a/build-logic/jacoco-testkit/src/main/kotlin/build-logic.jacoco-testkit.gradle.kts
+++ b/build-logic/jacoco-testkit/src/main/kotlin/build-logic.jacoco-testkit.gradle.kts
@@ -1,5 +1,4 @@
 import de.skuzzle.buildlogic.jacocotestkit.JacocoTestKitExtension
-import java.util.concurrent.Callable
 
 plugins {
     id("jacoco")
@@ -27,21 +26,22 @@ dependencies {
 }
 extension.agentClasspath.from(agentClasspath)
 
-tasks.withType<Test>().configureEach {
-    val instrumented = extension.testTasks.map { it.contains(name) }
-    val propertyName = extension.systemPropertyNames.javaAgentArgument
-    // The forked JVM has to append to this very file: it is the one the `jacoco` plugin registers
-    // as the task's coverage data, and hence the only one an aggregated report picks up.
-    val argument = extension.javaAgentArgument(
-        layout.file(provider { the<JacocoTaskExtension>().destinationFile })
-    )
+extension.instrumentedTaskNames.all {
+    val taskName = this
+    tasks.named<Test>(taskName) {
+        val propertyName = extension.systemPropertyNames.javaAgentArgument
+        // The forked JVM has to append to this very file: it is the one the `jacoco` plugin
+        // registers as the task's coverage data, and hence the only one a report aggregation picks
+        // up.
+        val argument = extension.javaAgentArgument(
+            layout.file(provider { the<JacocoTaskExtension>().destinationFile })
+        )
 
-    // Both of these are resolved after the configuration phase, so that this does not depend on
-    // whether the task is realized before or after the build script configures the extension.
-    inputs.files(Callable { if (instrumented.get()) agentClasspath else objects.fileCollection() })
-        .withPropertyName("jacocoTestKitAgent")
-        .withNormalizer(ClasspathNormalizer::class)
-    jvmArgumentProviders.add(CommandLineArgumentProvider {
-        if (instrumented.get()) listOf("-D${propertyName.get()}=${argument.get()}") else emptyList()
-    })
+        inputs.files(agentClasspath)
+            .withPropertyName("jacocoTestKitAgent")
+            .withNormalizer(ClasspathNormalizer::class)
+        jvmArgumentProviders.add(CommandLineArgumentProvider {
+            listOf("-D${propertyName.get()}=${argument.get()}")
+        })
+    }
 }

--- a/build-logic/jacoco-testkit/src/main/kotlin/build-logic.jacoco-testkit.gradle.kts
+++ b/build-logic/jacoco-testkit/src/main/kotlin/build-logic.jacoco-testkit.gradle.kts
@@ -1,0 +1,47 @@
+import de.skuzzle.buildlogic.jacocotestkit.JacocoTestKitExtension
+import java.util.concurrent.Callable
+
+plugins {
+    id("jacoco")
+}
+
+// Some of our tests do not exercise the code under test in their own JVM: the Gradle plugin's
+// functional tests drive a build through TestKit, which runs it in a Gradle daemon, and the Maven
+// integration tests hand their projects to the Maven invoker, which forks a Maven per project. The
+// agent that the `jacoco` plugin attaches records nothing of what happens in those JVMs.
+//
+// This plugin resolves a second agent and offers it as a `-javaagent` argument for such a JVM,
+// which the test - the only place that knows how the JVM is launched - passes on. A test task
+// hands it to its tests as a system property; other tasks can ask for it directly.
+
+val extension = extensions.create<JacocoTestKitExtension>(JacocoTestKitExtension.NAME)
+extension.systemPropertyNames.javaAgentArgument.convention("jacoco.agent.jvmarg")
+
+val agentDependencies = configurations.dependencyScope("jacocoTestKitAgent")
+val agentClasspath = configurations.resolvable("jacocoTestKitAgentClasspath") {
+    extendsFrom(agentDependencies.get())
+}
+dependencies {
+    // The `runtime` classifier artifact of the agent module *is* jacocoagent.jar
+    agentDependencies.name("org.jacoco:org.jacoco.agent:${jacoco.toolVersion}:runtime")
+}
+extension.agentClasspath.from(agentClasspath)
+
+tasks.withType<Test>().configureEach {
+    val instrumented = extension.testTasks.map { it.contains(name) }
+    val propertyName = extension.systemPropertyNames.javaAgentArgument
+    // The forked JVM has to append to this very file: it is the one the `jacoco` plugin registers
+    // as the task's coverage data, and hence the only one an aggregated report picks up.
+    val argument = extension.javaAgentArgument(
+        layout.file(provider { the<JacocoTaskExtension>().destinationFile })
+    )
+
+    // Both of these are resolved after the configuration phase, so that this does not depend on
+    // whether the task is realized before or after the build script configures the extension.
+    inputs.files(Callable { if (instrumented.get()) agentClasspath else objects.fileCollection() })
+        .withPropertyName("jacocoTestKitAgent")
+        .withNormalizer(ClasspathNormalizer::class)
+    jvmArgumentProviders.add(CommandLineArgumentProvider {
+        if (instrumented.get()) listOf("-D${propertyName.get()}=${argument.get()}") else emptyList()
+    })
+}

--- a/build-logic/jacoco-testkit/src/main/kotlin/de/skuzzle/buildlogic/jacocotestkit/JacocoTestKitExtension.kt
+++ b/build-logic/jacoco-testkit/src/main/kotlin/de/skuzzle/buildlogic/jacocotestkit/JacocoTestKitExtension.kt
@@ -1,25 +1,27 @@
 package de.skuzzle.buildlogic.jacocotestkit
 
+import javax.inject.Inject
 import org.gradle.api.Action
+import org.gradle.api.DomainObjectSet
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFile
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.testing.Test
 
-abstract class JacocoTestKitExtension {
+abstract class JacocoTestKitExtension @Inject constructor(objects: ObjectFactory) {
     companion object {
         const val NAME = "jacocoTestKit"
     }
 
     /**
-     * Names of the test tasks whose forked builds should record coverage. Prefer passing the tasks
-     * themselves to [testTasks].
+     * Names of the test tasks whose forked builds record coverage, as added by [testTasks]. The
+     * plugin instruments each one as it is added.
      */
-    abstract val testTasks: SetProperty<String>
+    val instrumentedTaskNames: DomainObjectSet<String> = objects.domainObjectSet(String::class.java)
 
     /** The system properties under which the instrumented test tasks talk to their tests. */
     @get:Nested
@@ -30,7 +32,7 @@ abstract class JacocoTestKitExtension {
 
     fun testTasks(vararg tasks: TaskProvider<out Test>) {
         // Reading only the name keeps the tasks unrealized
-        testTasks.addAll(tasks.map { it.name })
+        tasks.forEach { instrumentedTaskNames.add(it.name) }
     }
 
     fun systemPropertyNames(action: Action<in SystemPropertyNames>) {

--- a/build-logic/jacoco-testkit/src/main/kotlin/de/skuzzle/buildlogic/jacocotestkit/JacocoTestKitExtension.kt
+++ b/build-logic/jacoco-testkit/src/main/kotlin/de/skuzzle/buildlogic/jacocotestkit/JacocoTestKitExtension.kt
@@ -1,0 +1,60 @@
+package de.skuzzle.buildlogic.jacocotestkit
+
+import org.gradle.api.Action
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.testing.Test
+
+abstract class JacocoTestKitExtension {
+    companion object {
+        const val NAME = "jacocoTestKit"
+    }
+
+    /**
+     * Names of the test tasks whose forked builds should record coverage. Prefer passing the tasks
+     * themselves to [testTasks].
+     */
+    abstract val testTasks: SetProperty<String>
+
+    /** The system properties under which the instrumented test tasks talk to their tests. */
+    @get:Nested
+    abstract val systemPropertyNames: SystemPropertyNames
+
+    /** The resolved agent, set by the plugin. */
+    abstract val agentClasspath: ConfigurableFileCollection
+
+    fun testTasks(vararg tasks: TaskProvider<out Test>) {
+        // Reading only the name keeps the tasks unrealized
+        testTasks.addAll(tasks.map { it.name })
+    }
+
+    fun systemPropertyNames(action: Action<in SystemPropertyNames>) {
+        action.execute(systemPropertyNames)
+    }
+
+    /**
+     * The `-javaagent` argument that makes a JVM append its coverage to [destinationFile]. This is
+     * the only place that knows the agent's options, so that every forked JVM records the same way,
+     * no matter who launches it.
+     *
+     * Concurrent JVMs may share a destination file: the agent takes an exclusive lock on it.
+     */
+    fun javaAgentArgument(destinationFile: Provider<RegularFile>): Provider<String> =
+        destinationFile.map { file ->
+            "-javaagent:${agentClasspath.singleFile.absolutePath}" +
+                "=destfile=${file.asFile.absolutePath},append=true,dumponexit=true,jmx=false"
+        }
+
+    abstract class SystemPropertyNames {
+        /**
+         * The property under which an instrumented test task passes [javaAgentArgument] to its
+         * tests, for them to hand to the JVM they fork.
+         */
+        abstract val javaAgentArgument: Property<String>
+    }
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -23,5 +23,6 @@ include("release-plugin")
 include("verify-publication")
 include("code-style")
 include("maven-download")
+include("jacoco-testkit")
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,6 @@ mavenExec = { module = "gradle.plugin.com.github.dkorotych.gradle.maven.exec:gra
 [plugins]
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 github-release = { id = "com.github.breadmoirai.github-release", version = "2.5.2" }
-coveralls = { id = "com.github.kt3k.coveralls", version = "2.12.2" }
+coverallsJacoco = { id = "com.github.nbaztec.coveralls-jacoco", version = "1.2.20" }
 mavenExec = { id = "com.github.dkorotych.gradle-maven-exec", version = "4.0.1" }
 gradlePluginPublish = { id = "com.gradle.plugin-publish", version = "1.3.1" }

--- a/restrict-imports-enforcer-rule-maven-it/pom.xml
+++ b/restrict-imports-enforcer-rule-maven-it/pom.xml
@@ -25,8 +25,10 @@
                     </pomIncludes>
                     <parallelThreads>${fromGradle.integration-test-threads}</parallelThreads>
                     <writeJunitReport>true</writeJunitReport>
-                    <!--uncomment next line to debug invoker tests -->
-                    <!--<mavenOpts>-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000</mavenOpts> -->
+                    <!-- The rule under test runs in the Maven that the invoker forks per project, so
+                         this is where the build attaches its coverage agent. Append -Xdebug
+                         -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000 to debug. -->
+                    <mavenOpts>${fromGradle.maven-opts}</mavenOpts>
                 </configuration>
                 <executions>
                     <execution>

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -44,6 +44,14 @@ val crossVersionTests = listOf(libs.versions.mavenMin, libs.versions.mavenMax)
             .map { enforcerVersion -> CrossVersionTest(mavenVersion, enforcerVersion) }
     }
 
+// Only the newest combination records coverage. The agent slows every JVM the invoker forks, and
+// the invoker runs them in parallel against one local repository that starts out empty - which
+// Maven only accesses safely from concurrent processes as of 3.9, so instrumenting `mavenMin` races
+// it into downloading half a POM. Coverage is not lost by this: all four combinations put the same
+// rule code through the same paths.
+val instrumentedMavenVersion = libs.versions.mavenMax.get()
+val instrumentedEnforcerVersion = libs.versions.enforcerMax.get()
+
 val funcTestTasks = crossVersionTests
     .map { crossVersionTest ->
         val enforcerVersion = crossVersionTest.enforcerVersion.get()
@@ -55,6 +63,8 @@ val funcTestTasks = crossVersionTests
         val downloadTask = maven.download(mavenVersion)
 
         val taskName = "funcTestMaven_${safeMavenVersion}_enforcer_${safeEnforcerVersion}"
+        val recordsCoverage = mavenVersion == instrumentedMavenVersion &&
+            enforcerVersion == instrumentedEnforcerVersion
         // Every Maven the invoker forks appends to this one file; the agent locks it
         val coverageData = layout.buildDirectory.file("jacoco/$taskName.exec")
 
@@ -67,7 +77,9 @@ val funcTestTasks = crossVersionTests
 
             val mavenExecTask = this
 
-            outputs.file(coverageData).withPropertyName("coverageData")
+            if (recordsCoverage) {
+                outputs.file(coverageData).withPropertyName("coverageData")
+            }
 
             publishEnforcerRuleTask?.let { publishTask ->
                 mavenExecTask.dependsOn(publishTask)
@@ -108,14 +120,17 @@ val funcTestTasks = crossVersionTests
                     "fromGradle.invoker-plugin-version" to libs.versions.invokerPlugin.get(),
                     "fromGradle.integration-test-threads" to "2C",
                     "fromGradle.localIntegrationTestRepo" to m2Repository.get().dir("repository").asFile.absolutePath,
-                    "fromGradle.maven-opts" to jacocoTestKit.javaAgentArgument(coverageData).get()
+                    "fromGradle.maven-opts" to
+                        if (recordsCoverage) jacocoTestKit.javaAgentArgument(coverageData).get() else ""
                 )
             )
         }
 
-        artifacts.add(coverageDataElements.name, coverageData) {
-            type = ArtifactTypeDefinition.BINARY_DATA_TYPE
-            builtBy(funcTestTask)
+        if (recordsCoverage) {
+            artifacts.add(coverageDataElements.name, coverageData) {
+                type = ArtifactTypeDefinition.BINARY_DATA_TYPE
+                builtBy(funcTestTask)
+            }
         }
 
         funcTestTask

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -1,9 +1,27 @@
 import com.github.dkorotych.gradle.maven.exec.MavenExec
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.TestSuiteName
+import org.gradle.api.attributes.VerificationType
 
 plugins {
     id("build-logic.base")
     id("build-logic.maven-download")
+    id("build-logic.jacoco-testkit")
     alias(libs.plugins.mavenExec)
+}
+
+// This module has no sources of its own; it exercises the published enforcer rule through real
+// Maven builds. The coverage those record is exposed the way a test suite of a Java module would
+// expose it, so that test-coverage's aggregation picks it up by test suite name.
+val mavenFunctionalTestSuiteName = "mavenFunctionalTest"
+val coverageDataElements = configurations.consumable("coverageDataElementsForMavenFunctionalTest") {
+    description = "Binary results containing Jacoco test coverage of the Maven integration tests."
+    attributes {
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.VERIFICATION))
+        attribute(TestSuiteName.TEST_SUITE_NAME_ATTRIBUTE, objects.named(mavenFunctionalTestSuiteName))
+        attribute(VerificationType.VERIFICATION_TYPE_ATTRIBUTE, objects.named(VerificationType.JACOCO_RESULTS))
+    }
 }
 
 
@@ -36,7 +54,11 @@ val funcTestTasks = crossVersionTests
 
         val downloadTask = maven.download(mavenVersion)
 
-        tasks.register<MavenExec>("funcTestMaven_${safeMavenVersion}_enforcer_${safeEnforcerVersion}") {
+        val taskName = "funcTestMaven_${safeMavenVersion}_enforcer_${safeEnforcerVersion}"
+        // Every Maven the invoker forks appends to this one file; the agent locks it
+        val coverageData = layout.buildDirectory.file("jacoco/$taskName.exec")
+
+        val funcTestTask = tasks.register<MavenExec>(taskName) {
             description = "Executes Maven Enforcer Plugin integration tests"
             group = "verification"
             notCompatibleWithConfigurationCache("Inherently not")
@@ -44,6 +66,8 @@ val funcTestTasks = crossVersionTests
             dependsOn(downloadTask)
 
             val mavenExecTask = this
+
+            outputs.file(coverageData).withPropertyName("coverageData")
 
             publishEnforcerRuleTask?.let { publishTask ->
                 mavenExecTask.dependsOn(publishTask)
@@ -83,10 +107,18 @@ val funcTestTasks = crossVersionTests
                     "fromGradle.enforcer-api-version" to enforcerVersion,
                     "fromGradle.invoker-plugin-version" to libs.versions.invokerPlugin.get(),
                     "fromGradle.integration-test-threads" to "2C",
-                    "fromGradle.localIntegrationTestRepo" to m2Repository.get().dir("repository").asFile.absolutePath
+                    "fromGradle.localIntegrationTestRepo" to m2Repository.get().dir("repository").asFile.absolutePath,
+                    "fromGradle.maven-opts" to jacocoTestKit.javaAgentArgument(coverageData).get()
                 )
             )
         }
+
+        artifacts.add(coverageDataElements.name, coverageData) {
+            type = ArtifactTypeDefinition.BINARY_DATA_TYPE
+            builtBy(funcTestTask)
+        }
+
+        funcTestTask
     }
 
 funcTestTasks.forEach {

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -12,14 +12,14 @@ plugins {
 }
 
 // This module has no sources of its own; it exercises the published enforcer rule through real
-// Maven builds. The coverage those record is exposed the way a test suite of a Java module would
-// expose it, so that test-coverage's aggregation picks it up by test suite name.
-val mavenFunctionalTestSuiteName = "mavenFunctionalTest"
-val coverageDataElements = configurations.consumable("coverageDataElementsForMavenFunctionalTest") {
+// Maven builds. The coverage those record is exposed exactly the way the `functionalTest` suite of
+// a Java module would expose it, so that test-coverage's aggregation picks it up by suite name
+// along with every other functional test of the build.
+val coverageDataElements = configurations.consumable("coverageDataElementsForFunctionalTest") {
     description = "Binary results containing Jacoco test coverage of the Maven integration tests."
     attributes {
         attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.VERIFICATION))
-        attribute(TestSuiteName.TEST_SUITE_NAME_ATTRIBUTE, objects.named(mavenFunctionalTestSuiteName))
+        attribute(TestSuiteName.TEST_SUITE_NAME_ATTRIBUTE, objects.named("functionalTest"))
         attribute(VerificationType.VERIFICATION_TYPE_ATTRIBUTE, objects.named(VerificationType.JACOCO_RESULTS))
     }
 }

--- a/restrict-imports-gradle-plugin/restrict-imports-gradle-plugin.gradle.kts
+++ b/restrict-imports-gradle-plugin/restrict-imports-gradle-plugin.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     `kotlin-dsl`
     groovy
     `jvm-test-suite`
+    id("build-logic.jacoco-testkit")
     id("build-logic.published-java-component")
     id("build-logic.release-extension")
 }
@@ -76,33 +77,13 @@ val functionalTest = testing.suites.register<JvmTestSuite>("functionalTest") {
     }
 }
 
-// The functional tests exercise the plugin through TestKit, which runs the build under test in a
-// Gradle daemon rather than in the test JVM. The JaCoCo agent that the `jacoco` plugin attaches to
-// the test JVM therefore sees none of the plugin's code, so the tests have to attach a second agent
-// to that daemon themselves - see BaseRestrictsImportsFuncTest. This configuration resolves the
-// agent jar to attach; the `runtime` classifier artifact of the agent module *is* jacocoagent.jar.
-val testKitJacocoAgent: Configuration by configurations.creating {
-    isCanBeConsumed = false
-    isCanBeResolved = true
-    isVisible = false
-}
-dependencies {
-    testKitJacocoAgent("org.jacoco:org.jacoco.agent:${jacoco.toolVersion}:runtime")
-}
-
-tasks.named<Test>("functionalTest") {
-    val agentJar = testKitJacocoAgent
-    // The daemon has to append to this very file: it is the one the jacoco plugin registers as the
-    // task's coverage data, and hence the only one that test-coverage's aggregation picks up.
-    val execFile = the<JacocoTaskExtension>().destinationFile!!
-
-    inputs.files(agentJar).withPropertyName("testKitJacocoAgent").withNormalizer(ClasspathNormalizer::class)
-    jvmArgumentProviders.add(CommandLineArgumentProvider {
-        listOf(
-            "-Djacoco.agent.jar=${agentJar.singleFile.absolutePath}",
-            "-Djacoco.agent.destfile=${execFile.absolutePath}",
-        )
-    })
+// The functional tests drive the plugin through TestKit, so the coverage they produce is recorded
+// by the daemon they launch rather than by this task's JVM - see BaseRestrictsImportsFuncTest.
+jacocoTestKit {
+    testTasks(tasks.named<Test>("functionalTest"))
+    systemPropertyNames {
+        javaAgentArgument = "jacoco.agent.jvmarg"
+    }
 }
 
 tasks.named<Task>("check") {

--- a/restrict-imports-gradle-plugin/restrict-imports-gradle-plugin.gradle.kts
+++ b/restrict-imports-gradle-plugin/restrict-imports-gradle-plugin.gradle.kts
@@ -76,6 +76,35 @@ val functionalTest = testing.suites.register<JvmTestSuite>("functionalTest") {
     }
 }
 
+// The functional tests exercise the plugin through TestKit, which runs the build under test in a
+// Gradle daemon rather than in the test JVM. The JaCoCo agent that the `jacoco` plugin attaches to
+// the test JVM therefore sees none of the plugin's code, so the tests have to attach a second agent
+// to that daemon themselves - see BaseRestrictsImportsFuncTest. This configuration resolves the
+// agent jar to attach; the `runtime` classifier artifact of the agent module *is* jacocoagent.jar.
+val testKitJacocoAgent: Configuration by configurations.creating {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    isVisible = false
+}
+dependencies {
+    testKitJacocoAgent("org.jacoco:org.jacoco.agent:${jacoco.toolVersion}:runtime")
+}
+
+tasks.named<Test>("functionalTest") {
+    val agentJar = testKitJacocoAgent
+    // The daemon has to append to this very file: it is the one the jacoco plugin registers as the
+    // task's coverage data, and hence the only one that test-coverage's aggregation picks up.
+    val execFile = the<JacocoTaskExtension>().destinationFile!!
+
+    inputs.files(agentJar).withPropertyName("testKitJacocoAgent").withNormalizer(ClasspathNormalizer::class)
+    jvmArgumentProviders.add(CommandLineArgumentProvider {
+        listOf(
+            "-Djacoco.agent.jar=${agentJar.singleFile.absolutePath}",
+            "-Djacoco.agent.destfile=${execFile.absolutePath}",
+        )
+    })
+}
+
 tasks.named<Task>("check") {
     dependsOn(functionalTest)
 }

--- a/restrict-imports-gradle-plugin/src/functionalTest/groovy/de/skuzzle/restrictimports/gradle/BaseRestrictsImportsFuncTest.groovy
+++ b/restrict-imports-gradle-plugin/src/functionalTest/groovy/de/skuzzle/restrictimports/gradle/BaseRestrictsImportsFuncTest.groovy
@@ -24,8 +24,44 @@ abstract class BaseRestrictsImportsFuncTest extends Specification {
         org.gradle.caching=true
         org.gradle.configuration-cache=true
         """.stripIndent(true)
+        propertiesFile << jacocoDaemonProperties()
         settingsFile = workspace.file("settings${dsl.fileExtension}")
         buildFile = workspace.file("build${dsl.fileExtension}")
+    }
+
+    /**
+     * Whether the Gradle daemon that runs the build under test should record coverage, see
+     * {@link #jacocoDaemonProperties()}. Gradle 8 rejects a build that combines a Java agent with
+     * the configuration cache, which these tests always enable, so tests that run against an older
+     * Gradle have to turn this off.
+     */
+    protected boolean instrumentTestKitDaemon() {
+        return true
+    }
+
+    /**
+     * TestKit runs the build under test in a Gradle daemon, so the plugin's code never executes in
+     * this JVM and the JaCoCo agent that the build attaches to it records nothing for the plugin.
+     * Attach a second agent to that daemon, appending to the very file that the functionalTest task
+     * declares as its execution data, so that the coverage of these tests ends up in the aggregated
+     * report along with the unit tests'.
+     *
+     * <p>The daemon is single-use, which is what makes {@code dumponexit} write the data while the
+     * test is still running rather than whenever a reused daemon happens to expire.
+     *
+     * <p>Yields nothing when the two system properties are absent, so that the tests still run when
+     * they are started outside of the functionalTest task, e.g. from an IDE.
+     */
+    private String jacocoDaemonProperties() {
+        def agentJar = System.getProperty("jacoco.agent.jar")
+        def destFile = System.getProperty("jacoco.agent.destfile")
+        if (!instrumentTestKitDaemon() || agentJar == null || destFile == null) {
+            return ""
+        }
+        return """\
+        org.gradle.daemon=false
+        org.gradle.jvmargs=-javaagent:$agentJar=destfile=$destFile,append=true,dumponexit=true,jmx=false
+        """.stripIndent(true)
     }
 
     BuildResult run(String... arguments) {

--- a/restrict-imports-gradle-plugin/src/functionalTest/groovy/de/skuzzle/restrictimports/gradle/BaseRestrictsImportsFuncTest.groovy
+++ b/restrict-imports-gradle-plugin/src/functionalTest/groovy/de/skuzzle/restrictimports/gradle/BaseRestrictsImportsFuncTest.groovy
@@ -42,25 +42,23 @@ abstract class BaseRestrictsImportsFuncTest extends Specification {
     /**
      * TestKit runs the build under test in a Gradle daemon, so the plugin's code never executes in
      * this JVM and the JaCoCo agent that the build attaches to it records nothing for the plugin.
-     * Attach a second agent to that daemon, appending to the very file that the functionalTest task
-     * declares as its execution data, so that the coverage of these tests ends up in the aggregated
-     * report along with the unit tests'.
+     * Attach the agent that the build offers for exactly this to that daemon, so that the coverage
+     * of these tests ends up in the aggregated report along with the unit tests'.
      *
-     * <p>The daemon is single-use, which is what makes {@code dumponexit} write the data while the
-     * test is still running rather than whenever a reused daemon happens to expire.
+     * <p>The daemon is single-use, which is what makes the agent write its data while the test is
+     * still running rather than whenever a reused daemon happens to expire.
      *
-     * <p>Yields nothing when the two system properties are absent, so that the tests still run when
-     * they are started outside of the functionalTest task, e.g. from an IDE.
+     * <p>Yields nothing when the system property is absent, so that the tests still run when they
+     * are started outside of the functionalTest task, e.g. from an IDE.
      */
     private String jacocoDaemonProperties() {
-        def agentJar = System.getProperty("jacoco.agent.jar")
-        def destFile = System.getProperty("jacoco.agent.destfile")
-        if (!instrumentTestKitDaemon() || agentJar == null || destFile == null) {
+        def javaAgentArgument = System.getProperty("jacoco.agent.jvmarg")
+        if (!instrumentTestKitDaemon() || javaAgentArgument == null) {
             return ""
         }
         return """\
         org.gradle.daemon=false
-        org.gradle.jvmargs=-javaagent:$agentJar=destfile=$destFile,append=true,dumponexit=true,jmx=false
+        org.gradle.jvmargs=$javaAgentArgument
         """.stripIndent(true)
     }
 

--- a/restrict-imports-gradle-plugin/src/functionalTest/groovy/de/skuzzle/restrictimports/gradle/RestrictImportsGradleVersionFuncTest.groovy
+++ b/restrict-imports-gradle-plugin/src/functionalTest/groovy/de/skuzzle/restrictimports/gradle/RestrictImportsGradleVersionFuncTest.groovy
@@ -10,6 +10,14 @@ class RestrictImportsGradleVersionFuncTest extends BaseRestrictsImportsFuncTest 
         return GradleDSL.GROOVY
     }
 
+    @Override
+    protected boolean instrumentTestKitDaemon() {
+        // Gradle 8 fails a build that uses a Java agent together with the configuration cache, and
+        // this test intentionally runs with the configuration cache on. The coverage lost here is
+        // recorded by the tests that run against the current Gradle anyway.
+        return false
+    }
+
     def "plugin works without using deprecated Gradle API with Gradle #gradleVersion"() {
         given:
         javaClassWithImports([], "", "ClassWithNoBannedImports")

--- a/test-coverage/test-coverage.gradle.kts
+++ b/test-coverage/test-coverage.gradle.kts
@@ -12,34 +12,33 @@ dependencies {
     jacocoAggregation(projects.restrictImportsEnforcerRuleMavenIt)
 }
 
-// Report name to the name of the test suite it aggregates
-val reportsBySuiteName = mapOf(
-    "testCodeCoverageReport" to "test",
-    "functionalTestCodeCoverageReport" to "functionalTest",
-    "mavenFunctionalTestCodeCoverageReport" to "mavenFunctionalTest",
-)
+val unitTestReportName = "testCodeCoverageReport"
+val functionalTestReportName = "functionalTestCodeCoverageReport"
 reporting {
     reports {
-        reportsBySuiteName.forEach { (reportName, suiteName) ->
-            create<JacocoCoverageReport>(reportName) {
-                testSuiteName = suiteName
-            }
+        create<JacocoCoverageReport>(unitTestReportName) {
+            testSuiteName = "test"
+        }
+        create<JacocoCoverageReport>(functionalTestReportName) {
+            testSuiteName = "functionalTest"
         }
     }
 }
 
 // A JacocoCoverageReport covers exactly one test suite, but coveralls consumes a single report:
-// merge the execution data of all of them. The class and source directories are the same for every
-// one - they come from the aggregated projects, not from the suite - so taking them from any single
-// report covers all modules.
-val suiteReports = reportsBySuiteName.keys.map { tasks.named<JacocoReport>(it) }
+// merge the execution data of both aggregations. The class and source directories are the same
+// for both - they come from the aggregated projects, not from the suite - so taking them from
+// either report covers all modules.
+val unitTestReport = tasks.named<JacocoReport>(unitTestReportName)
+val functionalTestReport = tasks.named<JacocoReport>(functionalTestReportName)
 val allTestsReport = tasks.register<JacocoReport>("allTestsCodeCoverageReport") {
     group = "verification"
-    description = "Aggregates the coverage of every test suite of all projects"
+    description = "Aggregates the unit and functional test coverage of all projects"
 
-    suiteReports.forEach { report -> executionData.from(report.map { it.executionData }) }
-    classDirectories.from(suiteReports.first().map { it.classDirectories })
-    sourceDirectories.from(suiteReports.first().map { it.sourceDirectories })
+    executionData.from(unitTestReport.map { it.executionData })
+    executionData.from(functionalTestReport.map { it.executionData })
+    classDirectories.from(unitTestReport.map { it.classDirectories })
+    sourceDirectories.from(unitTestReport.map { it.sourceDirectories })
 
     reports {
         xml.required = true

--- a/test-coverage/test-coverage.gradle.kts
+++ b/test-coverage/test-coverage.gradle.kts
@@ -10,21 +10,46 @@ dependencies {
         .forEach { jacocoAggregation(project(it)) }
 }
 
-val coverageReportName = "testCodeCoverageReport"
+val unitTestReportName = "testCodeCoverageReport"
+val functionalTestReportName = "functionalTestCodeCoverageReport"
 reporting {
     reports {
-        create<JacocoCoverageReport>(coverageReportName) {
-            // The name of the test suite whose coverage data is aggregated, not the value of the
-            // `testType` attribute that this replaced in Gradle 8.13: a name that no suite has
-            // silently aggregates nothing, and the report task is SKIPPED for having no input.
+        // The names of the test suites whose coverage data is aggregated, not the values of the
+        // `testType` attribute that this replaced in Gradle 8.13: a name that no suite has
+        // silently aggregates nothing, and the report task is SKIPPED for having no input.
+        create<JacocoCoverageReport>(unitTestReportName) {
             testSuiteName = "test"
+        }
+        create<JacocoCoverageReport>(functionalTestReportName) {
+            testSuiteName = "functionalTest"
         }
     }
 }
 
+// A JacocoCoverageReport covers exactly one test suite, but coveralls consumes a single report:
+// merge the execution data of both aggregations. The class and source directories are the same
+// for both - they come from the aggregated projects, not from the suite - so taking them from
+// either report covers all modules.
+val unitTestReport = tasks.named<JacocoReport>(unitTestReportName)
+val functionalTestReport = tasks.named<JacocoReport>(functionalTestReportName)
+val allTestsReport = tasks.register<JacocoReport>("allTestsCodeCoverageReport") {
+    group = "verification"
+    description = "Aggregates the unit and functional test coverage of all projects"
+
+    executionData.from(unitTestReport.map { it.executionData })
+    executionData.from(functionalTestReport.map { it.executionData })
+    classDirectories.from(unitTestReport.map { it.classDirectories })
+    sourceDirectories.from(unitTestReport.map { it.sourceDirectories })
+
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
+    }
+}
+
 coverallsJacoco {
-    reportPath =
-        "${layout.buildDirectory.asFile.get().absolutePath}/reports/jacoco/${coverageReportName}/${coverageReportName}.xml"
+    reportPath = allTestsReport.get().reports.xml.outputLocation.get().asFile.absolutePath
     // Restricts the upload to our own sources: the aggregated report also covers the
     // dependencies that the published artifacts shade into themselves.
     reportSourceSets = rootProject.allJavaModules()
@@ -32,5 +57,5 @@ coverallsJacoco {
 }
 
 tasks.named("coverallsJacoco") {
-    dependsOn(coverageReportName)
+    dependsOn(allTestsReport)
 }

--- a/test-coverage/test-coverage.gradle.kts
+++ b/test-coverage/test-coverage.gradle.kts
@@ -14,9 +14,6 @@ val unitTestReportName = "testCodeCoverageReport"
 val functionalTestReportName = "functionalTestCodeCoverageReport"
 reporting {
     reports {
-        // The names of the test suites whose coverage data is aggregated, not the values of the
-        // `testType` attribute that this replaced in Gradle 8.13: a name that no suite has
-        // silently aggregates nothing, and the report task is SKIPPED for having no input.
         create<JacocoCoverageReport>(unitTestReportName) {
             testSuiteName = "test"
         }

--- a/test-coverage/test-coverage.gradle.kts
+++ b/test-coverage/test-coverage.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("build-logic.base")
     id("jacoco-report-aggregation")
-    alias(libs.plugins.coveralls)
+    alias(libs.plugins.coverallsJacoco)
 }
 
 dependencies {
@@ -14,19 +14,23 @@ val coverageReportName = "testCodeCoverageReport"
 reporting {
     reports {
         create<JacocoCoverageReport>(coverageReportName) {
-            testSuiteName = "unit-test"
+            // The name of the test suite whose coverage data is aggregated, not the value of the
+            // `testType` attribute that this replaced in Gradle 8.13: a name that no suite has
+            // silently aggregates nothing, and the report task is SKIPPED for having no input.
+            testSuiteName = "test"
         }
     }
 }
 
-coveralls {
-    sourceDirs = rootProject.allJavaModules()
-        .flatMap { it.sourceSets["main"].allSource.srcDirs }
-        .map { it.toString() }
-    jacocoReportPath =
+coverallsJacoco {
+    reportPath =
         "${layout.buildDirectory.asFile.get().absolutePath}/reports/jacoco/${coverageReportName}/${coverageReportName}.xml"
+    // Restricts the upload to our own sources: the aggregated report also covers the
+    // dependencies that the published artifacts shade into themselves.
+    reportSourceSets = rootProject.allJavaModules()
+        .flatMap { it.sourceSets["main"].allSource.srcDirs }
 }
 
-tasks.named("coveralls") {
+tasks.named("coverallsJacoco") {
     dependsOn(coverageReportName)
 }

--- a/test-coverage/test-coverage.gradle.kts
+++ b/test-coverage/test-coverage.gradle.kts
@@ -8,35 +8,38 @@ dependencies {
     rootProject.allJavaModules()
         .map { it.path }
         .forEach { jacocoAggregation(project(it)) }
+    // Has no sources of its own, but records coverage of the published enforcer rule
+    jacocoAggregation(projects.restrictImportsEnforcerRuleMavenIt)
 }
 
-val unitTestReportName = "testCodeCoverageReport"
-val functionalTestReportName = "functionalTestCodeCoverageReport"
+// Report name to the name of the test suite it aggregates
+val reportsBySuiteName = mapOf(
+    "testCodeCoverageReport" to "test",
+    "functionalTestCodeCoverageReport" to "functionalTest",
+    "mavenFunctionalTestCodeCoverageReport" to "mavenFunctionalTest",
+)
 reporting {
     reports {
-        create<JacocoCoverageReport>(unitTestReportName) {
-            testSuiteName = "test"
-        }
-        create<JacocoCoverageReport>(functionalTestReportName) {
-            testSuiteName = "functionalTest"
+        reportsBySuiteName.forEach { (reportName, suiteName) ->
+            create<JacocoCoverageReport>(reportName) {
+                testSuiteName = suiteName
+            }
         }
     }
 }
 
 // A JacocoCoverageReport covers exactly one test suite, but coveralls consumes a single report:
-// merge the execution data of both aggregations. The class and source directories are the same
-// for both - they come from the aggregated projects, not from the suite - so taking them from
-// either report covers all modules.
-val unitTestReport = tasks.named<JacocoReport>(unitTestReportName)
-val functionalTestReport = tasks.named<JacocoReport>(functionalTestReportName)
+// merge the execution data of all of them. The class and source directories are the same for every
+// one - they come from the aggregated projects, not from the suite - so taking them from any single
+// report covers all modules.
+val suiteReports = reportsBySuiteName.keys.map { tasks.named<JacocoReport>(it) }
 val allTestsReport = tasks.register<JacocoReport>("allTestsCodeCoverageReport") {
     group = "verification"
-    description = "Aggregates the unit and functional test coverage of all projects"
+    description = "Aggregates the coverage of every test suite of all projects"
 
-    executionData.from(unitTestReport.map { it.executionData })
-    executionData.from(functionalTestReport.map { it.executionData })
-    classDirectories.from(unitTestReport.map { it.classDirectories })
-    sourceDirectories.from(unitTestReport.map { it.sourceDirectories })
+    suiteReports.forEach { report -> executionData.from(report.map { it.executionData }) }
+    classDirectories.from(suiteReports.first().map { it.classDirectories })
+    sourceDirectories.from(suiteReports.first().map { it.sourceDirectories })
 
     reports {
         xml.required = true


### PR DESCRIPTION
The coverage badge has been reporting nothing. Two independent bugs, plus the
Gradle plugin module was never counted at all.

## The report was never written

`JacocoCoverageReport.testSuiteName` matches the *name of a test suite*, and the
unit tests live in the default `test` suite — but the report asked for
`unit-test`. That is the string value of the `testType` attribute this replaced
in Gradle 8.13, kept verbatim by that migration (be46757). Nothing matched, so
the report task had no input and was `SKIPPED` — while the build still reported
success.

## The upload itself is dead on Gradle 9

With the above fixed, the task fails:

```
Execution failed for task ':test-coverage:coveralls' (registered by plugin 'com.github.kt3k.coveralls').
> groovy/util/XmlParser
```

`org.kt3k...XmlParserFactory` has `groovy.util.XmlParser` hardcoded in its
bytecode; Groovy 4, which Gradle 9 ships, no longer has that class — it moved to
`groovy.xml.XmlParser` back in Groovy 3. Not configurable, and the plugin's last
release was 2.12.2 in 2022, so it is replaced with
`com.github.nbaztec.coveralls-jacoco`, whose documented setup is the
`jacoco-report-aggregation` one this build already uses.

`reportSourceSets` keeps the upload to our own sources — the aggregated report
also covers the dependencies that the published artifacts shade into themselves,
which is where its 34k uncovered javaparser lines come from.

## The functional tests now count too

The Gradle plugin module was at 0%, because only the `test` suite was aggregated
and the plugin's own code is exercised by its functional tests.

Aggregating the `functionalTest` suite is not enough on its own: TestKit runs the
build under test in a Gradle daemon, so none of the plugin's code executes in the
test JVM the JaCoCo agent is attached to. The suite's execution data records 21k
classes and not one of them belongs to the plugin. So the tests attach a second
agent to that daemon, appending to the very file the `functionalTest` task
declares as its coverage data — the only file the aggregation picks up. Being
single-use is what makes the daemon flush that data while the test is still
running, rather than whenever a reused daemon happens to expire.

A `JacocoCoverageReport` covers exactly one test suite but coveralls consumes a
single report, so the two aggregations are merged into one.

## The Maven integration tests now count too

Same problem one level deeper. The Maven ITs run the *published* enforcer rule
through real Maven builds, and the invoker forks a Maven per test project — so the
rule executes two JVMs away from anything the build instruments. The invoker
already has a knob for the options of those forked JVMs, the one the pom keeps
commented out for attaching a debugger, so the agent goes there.

All the forked Mavens of one cross-version task append to a single execution data
file. That is safe by design: JaCoCo's `FileOutput` takes an exclusive
`FileChannel.lock()` with retries, so concurrent agents sharing a file is
supported outright — which matters here, because the invoker runs them `2C`-parallel.

That module has no sources and no test suite of its own, so it exposes what it
records exactly the way a `functionalTest` suite of a Java module would — which
means one aggregation covers every functional test in the build, the Gradle
plugin's TestKit runs and all four Maven cross-version runs alike.

## Result

**Line coverage of our own sources: 74.7% → 89.9%** (46 files, 1349/1500 lines).

| module | before | after |
| --- | --- | --- |
| `restrict-imports-enforcer-rule` | 74.8% | **95.5%** |
| `restrict-imports-enforcer-rule-core` | 88.5% | 88.6% |
| `restrict-imports-gradle-plugin` | 0% | **90.0%** |

The wiring — resolve a second agent, hand it to a task for its tests to attach to
the JVM they fork — is generic, so it lives in a `build-logic:jacoco-testkit`
plugin rather than in either build script.

## Pipeline changes

The upload moved out of the `Unit-tests` stage into its own `Coverage` stage
after `Func-tests`, because it now needs the execution data of both.

`JenkinsfileRelease` no longer uploads at all: it has no `COVERALLS_REPO_TOKEN`
in its environment and the new plugin fails hard without one, so that step has
never done anything. The branch build reports coverage for every commit it
releases anyway.

## Trade-offs worth a look

- **The cross-version test contributes no coverage, deliberately.** Gradle 8
  rejects a TestKit build that combines a Java agent with the configuration
  cache, and `RestrictImportsGradleVersionFuncTest` enables the configuration
  cache on purpose. It opts out via an overridable `instrumentTestKitDaemon()` —
  including its current-Gradle row. Everything it would contribute is covered by
  the 17 tests that run against the current Gradle.
- **TestKit daemons are single-use** (`org.gradle.daemon=false`), because with
  `output=file` the agent only writes at JVM exit and a reused daemon does not
  exit when the build does. Measured cost: functionalTest runs in 12–27s
  depending on how warm the distributions are, against ~30s before. Keeping reuse
  is possible via `output=tcpserver` plus an explicit dump per build — worth it
  only if that time starts to matter.
- **`coverallsJacoco` now depends on the Maven IT chain**, which depends on
  publishing to the local integration test repository. On Jenkins that is already
  done by the Func-tests stage; locally it means the upload task pulls in a
  publish it did not before.

## Verification

The CI task sequence was run locally on this branch — `quickCheck`,
`build-logic:check`, `clean test functionalTest`,
`generateReadmeAndReleaseNotes` — and `coverallsJacoco` under a forced `dryRun`,
which produces the payload above with the correct `service_name`,
`service_job_id` and `service_branch`. Repeated once cold with `clean` and
`--no-build-cache` to confirm the numbers do not depend on restored task
outputs.

Not covered by that: the actual POST to coveralls.io. `dryRun` exercises
everything up to the network boundary, so the first real build on develop is the
proof. That path is plain Kotlin/JDK rather than Groovy-dependent, so it is
unlikely to hit the failure the old plugin did.

## Out of scope

- `./gradlew check` fails on `:restrict-imports-gradle-plugin:validatePlugins`
  (3 problems in `RestrictImports`: missing
  `@CacheableTask`/`@DisableCachingByDefault`, and no normalization on
  `mainSourceSet`/`testSourceSet`). Pre-existing — no main sources are touched
  here, and CI never runs the root `check`, which is why nobody has hit it.
- No `RELEASE_NOTES.md` entry — this is build infrastructure only.
