### PR TITLE
Release notes for 3.0.2

### DIFF
--- a/readme/RELEASE_NOTES.md
+++ b/readme/RELEASE_NOTES.md
@@ -1,10 +1,13 @@
 [![Maven Central](https://img.shields.io/static/v1?label=MavenCentral&message=@project.version@&color=blue)](https://search.maven.org/artifact/@project.groupId@/restrict-imports-enforcer-rule/@project.version@/jar) [![Gradle Plugin Portal](https://img.shields.io/gradle-plugin-portal/v/@project.pluginId@?versionSuffix=@project.version@)](https://plugins.gradle.org/plugin/@project.pluginId@/@project.version@)
 
 > [!NOTE]
-> The Gradle plugin is now tested against the latest Gradle 7.x, 8.x and 9.x releases
+> This release contains no functional changes. A release dry run accidentally promoted its
+> staging repository, which published `3.0.2-develop` to Maven Central and left it there as
+> the latest version of `de.skuzzle.enforcer:restrict-imports-enforcer-rule`. This release
+> supersedes those artifacts with a proper release. Do not use `3.0.2-develop`.
 
-### Bug fixes
-* [#274](https://github.com/skuzzle/restrict-imports-enforcer-rule/issues/274) The Gradle plugin no longer uses the deprecated `Project.getProperties` method, which emits a deprecation warning since Gradle 9.6 and would have become an error in Gradle 10
+### Documentation
+* [#278](https://github.com/skuzzle/restrict-imports-enforcer-rule/pull/278) The legacy `buildscript` snippet below now declares the Gradle plugin under `de.skuzzle.restrictimports:restrict-imports-gradle-plugin`. The `de.skuzzle.enforcer` coordinates documented until 3.0.1 never existed on Maven Central, so the declared dependency could not be resolved
 
 ### Dependency coordinates
 <details>


### PR DESCRIPTION
3.0.2 exists only to supersede `3.0.2-develop`, which a release dry run published to Maven Central by promoting its own staging repository (fixed since, in #277).

That version is not merely sitting there unused — Maven Central advertises it as the current release:

```xml
<latest>3.0.2-develop</latest>
<release>3.0.2-develop</release>
```

So the notes lead with the accident and tell people not to use it. The claim is scoped to Maven Central on purpose: the Gradle Plugin Portal's own metadata still reports 3.0.1 as latest.

Only the `readme/RELEASE_NOTES.md` template is touched, following the 3.0.1 precedent (ca10c55) — Jenkins regenerates the root `RELEASE_NOTES.md` and `README.md` in the release commit itself.

### Content decisions

- The 3.0.1 content is replaced: the Gradle 7.x/8.x/9.x testing note and the #274 entry belong to that release.
- #278 (legacy `buildscript` coordinates) is the one entry carried over. It is genuinely in the release diff and user-facing.
- Omitted as build-internal: the assertj bump (#279), the Renovate switch, and the release dry-run fixes (#277).

### Note on the version number

Maven's `ComparableVersion` sorts an unknown qualifier like `develop` *after* the bare version, so some Maven tooling may keep offering `3.0.2-develop` as an upgrade even once 3.0.2 is out. Releasing 3.0.3 instead would sidestep that. Nothing in the notes text depends on the ordering either way.

### Release steps after merge

Trigger `JenkinsfileRelease` from `develop` with `RELEASE_VERSION=3.0.2`.