### PR TITLE
Enable release dry run by default

### DIFF
--- a/JenkinsfileRelease
+++ b/JenkinsfileRelease
@@ -31,7 +31,7 @@ pipeline {
     }
     parameters {
         string(name: 'RELEASE_VERSION', defaultValue: '', description: 'Version to be released')
-        booleanParam(name: 'RELEASE_DRY_RUN', defaultValue: false, description: 'Whether to push releases to GitHub')
+        booleanParam(name: 'RELEASE_DRY_RUN', defaultValue: true, description: 'If true (the default), performs a dry run: nothing is pushed to GitHub or published. Uncheck to perform a real release')
         booleanParam(name: 'RELEASE_VERBOSE', defaultValue: false, description: 'Whether to print more verbose logs during release')
         booleanParam(name: 'RELEASE_MERGE_BRANCHES', defaultValue: false, description: 'If true, dev branch will be merged and push to main. Disable this for release candidates. No effect when dry run is true')
     }

--- a/build-logic/release-plugin/src/main/kotlin/build-logic.release-extension.gradle.kts
+++ b/build-logic/release-plugin/src/main/kotlin/build-logic.release-extension.gradle.kts
@@ -10,11 +10,13 @@ val releaseExtension = extensions.create<ReleaseExtension>(ReleaseExtension.NAME
             .orElse(providers.environmentVariable("RELEASE_VERSION"))
             .orElse(providers.gradleProperty("releaseVersion"))
     )
+    // Dry run is the safe default: a real release must opt in explicitly by setting one of
+    // the properties below to 'false'.
     dryRun.convention(
         providers.systemProperty("RELEASE_DRY_RUN").map { it == "true" }
             .orElse(providers.environmentVariable("RELEASE_DRY_RUN").map { it == "true" })
             .orElse(providers.gradleProperty("releaseDryRun").map { it == "true" })
-            .orElse(false)
+            .orElse(true)
     )
     verbose.convention(
         providers.systemProperty("RELEASE_VERBOSE").map { it == "true" }

--- a/build-logic/release-plugin/src/main/kotlin/de/skuzzle/release/AbstractReleaseStep.kt
+++ b/build-logic/release-plugin/src/main/kotlin/de/skuzzle/release/AbstractReleaseStep.kt
@@ -36,7 +36,7 @@ abstract class AbstractReleaseStep() : DefaultTask() {
     val git: Git
 
     init {
-        dryRun.convention(false)
+        dryRun.convention(true)
         verbose.convention(true)
         git = Git(providers, dryRun, verbose)
     }


### PR DESCRIPTION
A release is irreversible, an accidental dry run is not, so the safe mode is the one that should not require remembering a flag. Every layer that decides the mode now defaults to a dry run:

| Layer | Before | After |
| --- | --- | --- |
| `JenkinsfileRelease` `RELEASE_DRY_RUN` parameter | `false` | `true` |
| `build-logic.release-extension` `dryRun` convention fallback | `false` | `true` |
| `AbstractReleaseStep` `dryRun` convention | `false` | `true` |

An explicit opt-out still wins everywhere. The property providers map an unset value to absent rather than to `false`, so `-PreleaseDryRun=false`, `RELEASE_DRY_RUN=false` and an unchecked Jenkins checkbox all resolve to a real release.

The `RELEASE_DRY_RUN` parameter description was also inverted, describing a flag that suppresses pushes as "whether to push releases to GitHub". With the default flipped it would have been actively misleading in the Jenkins UI.

## Verification

Task graphs inspected with `--dry-run`, on this branch:

| Mode | Staging promotion | Plugin Portal |
| --- | --- | --- |
| default, nothing set | `Not promoting the staging repository because release dry run is enabled` | `validate-only` |
| `RELEASE_DRY_RUN=false` | `closeAndReleaseStagingRepositories` wired | real publish |

`./gradlew build-logic:check` and `./gradlew quickCheck` both pass. Version calculation is unaffected: `Git` only suppresses `commit`/`pull`/`merge`/`checkout`/`push`, and `calculateVersion()` uses read-only commands.

This composes with #277: that gate reads `release.dryRun.get()` at configuration time, so it picks up the new default directly. Publishing to the staging repository stays unguarded, as intended there.

## Note for whoever runs the release

Jenkins only picks up new parameter definitions after the job has run once with the updated `JenkinsfileRelease`, so the first build after merge may still show the old default. From then on, a real release requires actively unchecking the box.