### PR TITLE
Tag release builds in Develocity

### DIFF
--- a/JenkinsfileRelease
+++ b/JenkinsfileRelease
@@ -15,6 +15,8 @@ pipeline {
         // Enables Build Scan publishing and pushing to the remote build cache, both of which
         // the build gates on this variable being set. Jenkins does not set it by itself.
         CI = 'true'
+        // Tags the Build Scans produced by this pipeline as 'release-build' in Develocity.
+        RELEASE_BUILD = 'true'
         GITHUB = credentials('Github-Username-Pw')
         GIT_ASKPASS = './.git-askpass'
         RELEASE_GITHUB_TOKEN = credentials('github_registry_release')

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,11 +11,20 @@ plugins {
 }
 
 val isCI = System.getenv("CI") != null
+val isReleaseBuild = System.getenv("RELEASE_BUILD") != null
+// Mirrors how the release plugin resolves its own dry run flag
+val isDryRunRelease = (System.getProperty("RELEASE_DRY_RUN") ?: System.getenv("RELEASE_DRY_RUN")) == "true"
 
 develocity {
     server = "https://community.develocity.cloud"
     projectId = "skuzzle"
     buildScan {
+        if (isReleaseBuild) {
+            tag("release-build")
+            if (isDryRunRelease) {
+                tag("release-dry-run")
+            }
+        }
         uploadInBackground = !isCI
         publishing.onlyIf { it.isAuthenticated }
         obfuscation {


### PR DESCRIPTION
Release builds are now identifiable in Develocity by a Build Scan tag.

## What changed

- `JenkinsfileRelease` exports `RELEASE_BUILD=true` for the whole pipeline.
- The root `settings.gradle.kts` tags the Build Scan `release-build` when that variable is set, and additionally `release-dry-run` when the release is a dry run.

## Notes

- The variable is set at pipeline level, so **every** Gradle invocation of the release pipeline is tagged (`quickCheck`, `test coveralls`, `functionalTest`, `prepareRelease`, `releaseGitLocal`, `pushRelease`), not just the publishing stages.
- No Jenkinsfile change was needed for the dry run flag: Jenkins already exports the `RELEASE_DRY_RUN` boolean parameter into the environment, which is exactly how `build-logic.release-extension.gradle.kts` picks it up. The tag mirrors that resolution order (system property, then environment variable) so it can not disagree with what the release tasks actually did.
- `build-logic/settings.gradle.kts` is deliberately untouched: the release pipeline only invokes Gradle from the root build, so a tag there would be dead code.

## Verification

`./gradlew help` configures cleanly with `RELEASE_BUILD=true` combined with both `RELEASE_DRY_RUN=true` and `RELEASE_DRY_RUN=false`. The tags themselves are only observable on a published scan from the release pipeline.