### PR TITLE
Report Maven func test results as tests in Build Scans

### DIFF
--- a/build-logic/conventions/src/main/kotlin/MavenInvokerTestReporting.kt
+++ b/build-logic/conventions/src/main/kotlin/MavenInvokerTestReporting.kt
@@ -1,0 +1,98 @@
+import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports
+import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import java.io.File
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+/**
+ * Reports the results of a Maven Invoker Plugin run as tests in the Build Scan.
+ *
+ * The invoker plugin already writes a JUnit XML report per integration test (see
+ * `<writeJunitReport>` in the maven-it pom), so all that is needed is to hand those
+ * reports to Develocity. This registers a finalizer of [invokerTask] which imports them
+ * as real test executions, attributed to [invokerTask] itself.
+ *
+ * This is an extension on [Project] rather than on the Maven exec task: the conventions
+ * build does not depend on the maven-exec plugin and therefore can not see its task type,
+ * and registering the import task needs the `TaskContainer` at configuration time, which
+ * a `TaskProvider` can only reach by realizing itself.
+ *
+ * @param invokerTask The task running the Maven Invoker Plugin.
+ * @param invokerOutputDir That task's output directory.
+ */
+fun Project.importMavenInvokerTestResults(
+    invokerTask: TaskProvider<out Task>,
+    invokerOutputDir: Provider<Directory>
+) {
+    // 'reports' must match <reportsDirectory> in the maven-it pom. Both directories live
+    // inside the invoker task's output directory, so the normalized copies are part of
+    // its build cache entry and survive a cache hit.
+    val invokerReportsDir = invokerOutputDir.map { it.dir("reports") }
+    val normalizedReportsDir = invokerOutputDir.map { it.dir("develocity-junit-reports") }
+
+    invokerTask.configure {
+        doLast("normalize JUnit XML for Develocity") {
+            normalizeInvokerReports(invokerReportsDir.get().asFile, normalizedReportsDir.get().asFile)
+        }
+    }
+
+    ImportJUnitXmlReports.register(tasks, invokerTask, JUnitXmlDialect.GENERIC).configure {
+        // setFrom replaces the default, which is the whole output file tree of the
+        // reference task: that would also feed the parser the invoker's own BUILD-*.xml
+        // (a <build-job> format, not JUnit XML) and the cloned projects under builds/.
+        reports.setFrom(normalizedReportsDir.map { it.asFileTree.matching { include("TEST-*.xml") } })
+    }
+}
+
+/**
+ * Writes copies of the invoker's JUnit XML reports that Develocity's parser accepts.
+ *
+ * The originals are left untouched, so the invoker's own reports stay as it wrote them.
+ */
+private fun normalizeInvokerReports(invokerReportsDir: File, normalizedReportsDir: File) {
+    normalizedReportsDir.deleteRecursively()
+    normalizedReportsDir.mkdirs()
+
+    invokerReportsDir
+        .listFiles { file -> file.name.startsWith("TEST-") && file.name.endsWith(".xml") }
+        .orEmpty()
+        .forEach { report ->
+            normalizedReportsDir.resolve(report.name).writeText(withTimestamp(report))
+        }
+}
+
+private val testSuiteDuration = Regex("<testsuite\\b[^>]*\\btime=\"([^\"]*)\"")
+
+/**
+ * Adds the 'timestamp' attribute that the Maven Invoker Plugin never writes on
+ * `<testsuite>` (still true as of 3.10.1), but which Develocity's JUnit XML parser
+ * requires, aborting the whole import without it.
+ */
+private fun withTimestamp(report: File): String {
+    val xml = report.readText()
+    // Only look at the opening <testsuite> tag: <system-out> embeds the whole Maven build
+    // log, which may well contain 'timestamp=' itself.
+    if (xml.substringBefore('>').contains("timestamp=")) {
+        return xml
+    }
+
+    // The invoker writes each report once its build job has finished, so the file's
+    // modification time minus the recorded duration approximates when that job started.
+    // There is no better source: the XML records no start time.
+    val durationMillis = testSuiteDuration.find(xml)
+        ?.groupValues?.get(1)?.toDoubleOrNull()
+        ?.times(1000)?.toLong()
+        ?: 0L
+    val startedAt = Instant.ofEpochMilli(report.lastModified()).minusMillis(durationMillis)
+    val timestamp = OffsetDateTime.ofInstant(startedAt, ZoneId.systemDefault())
+        .truncatedTo(ChronoUnit.SECONDS)
+
+    return xml.replaceFirst("<testsuite ", "<testsuite timestamp=\"$timestamp\" ")
+}

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -1,4 +1,10 @@
 import com.github.dkorotych.gradle.maven.exec.MavenExec
+import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports
+import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 
 plugins {
     id("build-logic.base")
@@ -36,7 +42,14 @@ val funcTestTasks = crossVersionTests
 
         val downloadTask = maven.download(mavenVersion)
 
-        tasks.register<MavenExec>("funcTestMaven_${safeMavenVersion}_enforcer_${safeEnforcerVersion}") {
+        val taskName = "funcTestMaven_${safeMavenVersion}_enforcer_${safeEnforcerVersion}"
+
+        // JUnit XML as written by the Maven Invoker Plugin, and the copies of it that are
+        // normalized for Develocity (see the doLast block below).
+        val invokerReportsDir = layout.buildDirectory.dir("$taskName/reports")
+        val develocityReportsDir = layout.buildDirectory.dir("$taskName/develocity-junit-reports")
+
+        val funcTestTask = tasks.register<MavenExec>(taskName) {
             description = "Executes Maven Enforcer Plugin integration tests"
             group = "verification"
             notCompatibleWithConfigurationCache("Inherently not")
@@ -78,7 +91,7 @@ val funcTestTasks = crossVersionTests
             define(
                 mapOf(
                     "revision" to project.version.toString(),
-                    "fromGradle.test-id" to "maven.invoker.it._$safeEnforcerVersion",
+                    "fromGradle.test-id" to "maven.invoker.it.maven_$safeMavenVersion.enforcer_$safeEnforcerVersion",
                     "fromGradle.output-dir" to outputDir,
                     "fromGradle.enforcer-api-version" to enforcerVersion,
                     "fromGradle.invoker-plugin-version" to libs.versions.invokerPlugin.get(),
@@ -86,7 +99,60 @@ val funcTestTasks = crossVersionTests
                     "fromGradle.localIntegrationTestRepo" to m2Repository.get().dir("repository").asFile.absolutePath
                 )
             )
+
+            doLast("normalize JUnit XML for Develocity") {
+                // The Maven Invoker Plugin never writes the 'timestamp' attribute on
+                // <testsuite> (still true as of 3.10.1), but Develocity's JUnit XML parser
+                // requires it and aborts the whole import without it. Write normalized
+                // copies rather than editing the originals, so the invoker's own reports
+                // stay untouched. Both directories live inside this task's output
+                // directory, so the copies survive a build cache hit as well.
+                val reportsDir = invokerReportsDir.get().asFile
+                val normalizedDir = develocityReportsDir.get().asFile
+                normalizedDir.deleteRecursively()
+                normalizedDir.mkdirs()
+
+                // The invoker writes each report once its build job has finished, so the
+                // file's modification time minus the recorded duration approximates when
+                // that job started. There is no better source: the XML records no start.
+                val durationPattern = Regex("<testsuite\\b[^>]*\\btime=\"([^\"]*)\"")
+
+                reportsDir.listFiles { file -> file.name.startsWith("TEST-") && file.name.endsWith(".xml") }
+                    .orEmpty()
+                    .forEach { report ->
+                        val xml = report.readText()
+                        // Only look at the opening <testsuite> tag: <system-out> embeds the
+                        // whole Maven build log, which may well contain 'timestamp=' itself.
+                        val normalized = if (xml.substringBefore('>').contains("timestamp=")) {
+                            xml
+                        } else {
+                            val durationMillis = durationPattern.find(xml)
+                                ?.groupValues?.get(1)?.toDoubleOrNull()
+                                ?.times(1000)?.toLong()
+                                ?: 0L
+                            val startedAt = Instant.ofEpochMilli(report.lastModified())
+                                .minusMillis(durationMillis)
+                            val timestamp = OffsetDateTime.ofInstant(startedAt, ZoneId.systemDefault())
+                                .truncatedTo(ChronoUnit.SECONDS)
+                            xml.replaceFirst("<testsuite ", """<testsuite timestamp="$timestamp" """)
+                        }
+                        normalizedDir.resolve(report.name).writeText(normalized)
+                    }
+            }
         }
+
+        // Report the Maven Invoker results as tests in the Build Scan. The invoker plugin
+        // already writes JUnit XML (see <writeJunitReport> in pom.xml); this registers a
+        // finalizer task that hands those reports to Develocity, attributed to the
+        // MavenExec task that produced them.
+        ImportJUnitXmlReports.register(tasks, funcTestTask, JUnitXmlDialect.GENERIC).configure {
+            // setFrom replaces the default, which is the task's entire output file tree:
+            // that would also feed the parser the invoker's own BUILD-*.xml (a <build-job>
+            // format, not JUnit XML) and the cloned projects under builds/.
+            reports.setFrom(develocityReportsDir.map { it.asFileTree.matching { include("TEST-*.xml") } })
+        }
+
+        funcTestTask
     }
 
 funcTestTasks.forEach {

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -1,10 +1,4 @@
 import com.github.dkorotych.gradle.maven.exec.MavenExec
-import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports
-import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect
-import java.time.Instant
-import java.time.OffsetDateTime
-import java.time.ZoneId
-import java.time.temporal.ChronoUnit
 
 plugins {
     id("build-logic.base")
@@ -44,10 +38,7 @@ val funcTestTasks = crossVersionTests
 
         val taskName = "funcTestMaven_${safeMavenVersion}_enforcer_${safeEnforcerVersion}"
 
-        // JUnit XML as written by the Maven Invoker Plugin, and the copies of it that are
-        // normalized for Develocity (see the doLast block below).
-        val invokerReportsDir = layout.buildDirectory.dir("$taskName/reports")
-        val develocityReportsDir = layout.buildDirectory.dir("$taskName/develocity-junit-reports")
+        val taskOutputDir = layout.buildDirectory.dir(taskName)
 
         val funcTestTask = tasks.register<MavenExec>(taskName) {
             description = "Executes Maven Enforcer Plugin integration tests"
@@ -64,7 +55,6 @@ val funcTestTasks = crossVersionTests
                 mavenExecTask.inputs.files(publishTask.project.tasks.withType<JavaCompile>())
             }
 
-            val outputDir = mavenExecTask.name
             inputs.files(layout.projectDirectory.dir("src/it/maven"))
                 .withPropertyName("mavenIntegrationTestSources")
                 .withPathSensitivity(PathSensitivity.RELATIVE)
@@ -74,7 +64,7 @@ val funcTestTasks = crossVersionTests
             inputs.files(layout.projectDirectory.file("pom.xml"))
                 .withPropertyName("mavenItPom")
                 .withPathSensitivity(PathSensitivity.RELATIVE)
-            outputs.dir(layout.buildDirectory.file(outputDir))
+            outputs.dir(taskOutputDir)
 
             // Opt this task into the build cache. The MavenExec task type from the
             // 'com.github.dkorotych.gradle-maven-exec' plugin is not annotated
@@ -92,65 +82,17 @@ val funcTestTasks = crossVersionTests
                 mapOf(
                     "revision" to project.version.toString(),
                     "fromGradle.test-id" to "maven.invoker.it.maven_$safeMavenVersion.enforcer_$safeEnforcerVersion",
-                    "fromGradle.output-dir" to outputDir,
+                    "fromGradle.output-dir" to taskName,
                     "fromGradle.enforcer-api-version" to enforcerVersion,
                     "fromGradle.invoker-plugin-version" to libs.versions.invokerPlugin.get(),
                     "fromGradle.integration-test-threads" to "2C",
                     "fromGradle.localIntegrationTestRepo" to m2Repository.get().dir("repository").asFile.absolutePath
                 )
             )
-
-            doLast("normalize JUnit XML for Develocity") {
-                // The Maven Invoker Plugin never writes the 'timestamp' attribute on
-                // <testsuite> (still true as of 3.10.1), but Develocity's JUnit XML parser
-                // requires it and aborts the whole import without it. Write normalized
-                // copies rather than editing the originals, so the invoker's own reports
-                // stay untouched. Both directories live inside this task's output
-                // directory, so the copies survive a build cache hit as well.
-                val reportsDir = invokerReportsDir.get().asFile
-                val normalizedDir = develocityReportsDir.get().asFile
-                normalizedDir.deleteRecursively()
-                normalizedDir.mkdirs()
-
-                // The invoker writes each report once its build job has finished, so the
-                // file's modification time minus the recorded duration approximates when
-                // that job started. There is no better source: the XML records no start.
-                val durationPattern = Regex("<testsuite\\b[^>]*\\btime=\"([^\"]*)\"")
-
-                reportsDir.listFiles { file -> file.name.startsWith("TEST-") && file.name.endsWith(".xml") }
-                    .orEmpty()
-                    .forEach { report ->
-                        val xml = report.readText()
-                        // Only look at the opening <testsuite> tag: <system-out> embeds the
-                        // whole Maven build log, which may well contain 'timestamp=' itself.
-                        val normalized = if (xml.substringBefore('>').contains("timestamp=")) {
-                            xml
-                        } else {
-                            val durationMillis = durationPattern.find(xml)
-                                ?.groupValues?.get(1)?.toDoubleOrNull()
-                                ?.times(1000)?.toLong()
-                                ?: 0L
-                            val startedAt = Instant.ofEpochMilli(report.lastModified())
-                                .minusMillis(durationMillis)
-                            val timestamp = OffsetDateTime.ofInstant(startedAt, ZoneId.systemDefault())
-                                .truncatedTo(ChronoUnit.SECONDS)
-                            xml.replaceFirst("<testsuite ", """<testsuite timestamp="$timestamp" """)
-                        }
-                        normalizedDir.resolve(report.name).writeText(normalized)
-                    }
-            }
         }
 
-        // Report the Maven Invoker results as tests in the Build Scan. The invoker plugin
-        // already writes JUnit XML (see <writeJunitReport> in pom.xml); this registers a
-        // finalizer task that hands those reports to Develocity, attributed to the
-        // MavenExec task that produced them.
-        ImportJUnitXmlReports.register(tasks, funcTestTask, JUnitXmlDialect.GENERIC).configure {
-            // setFrom replaces the default, which is the task's entire output file tree:
-            // that would also feed the parser the invoker's own BUILD-*.xml (a <build-job>
-            // format, not JUnit XML) and the cloned projects under builds/.
-            reports.setFrom(develocityReportsDir.map { it.asFileTree.matching { include("TEST-*.xml") } })
-        }
+        // Report the Maven Invoker results as tests in the Build Scan.
+        importMavenInvokerTestResults(funcTestTask, taskOutputDir)
 
         funcTestTask
     }


### PR DESCRIPTION
Now that Develocity is onboarded, the Maven integration tests show up in Build Scans only as opaque `MavenExec` tasks. This imports them as real test executions.

## How

The Maven Invoker Plugin already writes JUnit XML for every integration test (`<writeJunitReport>` in the maven-it pom), so no Maven-side change was needed. Develocity's Gradle plugin has a first-class API for ingesting it — `ImportJUnitXmlReports` — registered here as a finalizer of each cross-version `funcTestMaven_*` task, attributing the tests to the task that produced them.

Two adjustments were required to make the import actually work:

- **Restrict the imported reports.** The default report set is the task's entire output file tree, which would also feed the parser the invoker's own `BUILD-*.xml` (a `<build-job>` format, not JUnit XML) and the 31 cloned Maven projects under `builds/`. Now it's just `TEST-*.xml`.

- **Add the missing `timestamp` attribute.** Develocity's parser requires it on `<testsuite>` and aborts the whole import without it (`Missing required attribute 'timestamp'`). The invoker plugin has never written that attribute — I checked the sources of the current 3.10.1, so upgrading would not help. A `doLast` step writes normalized copies alongside the originals, deriving each start time from file mtime minus the recorded duration. Both directories live inside the task's output directory, so the copies survive a build cache hit.

## Deliberate behaviour changes

- **`junitPackageName` now includes the Maven version.** It encoded only the enforcer version (`maven.invoker.it._3_6_1`), so the two Maven versions produced identical test names for the same integration test. Now `maven.invoker.it.maven_3_9_11.enforcer_3_6_1`. This breaks historical test-name continuity and invalidates each variant's cache entry once.

- **An up-to-date or cached `funcTestMaven_*` contributes no test data to that scan**, because the import task is skipped along with its reference task. This matches how a native up-to-date `Test` task behaves.

## Verification

`functionalTest --rerun-tasks`: all 4 `MavenExec` + 4 import tasks executed, zero parse errors, 31 normalized reports per variant, 4 distinct package names.

To confirm "no errors" was a real signal rather than silence, I stripped a `timestamp` from one normalized report and re-ran — which also established that the import genuinely skips when its reference task does not run.

Scan from the final run: https://community.develocity.cloud/s/l5bb63ijkqve4