### PR TITLE
Fix the Maven invoker func tests, and report them when they fail

### DIFF
--- a/build-logic/conventions/src/main/kotlin/MavenInvokerTestReporting.kt
+++ b/build-logic/conventions/src/main/kotlin/MavenInvokerTestReporting.kt
@@ -1,9 +1,9 @@
 import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports
 import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.AbstractExecTask
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
 import java.time.Instant
@@ -19,16 +19,17 @@ import java.time.temporal.ChronoUnit
  * reports to Develocity. This registers a finalizer of [invokerTask] which imports them
  * as real test executions, attributed to [invokerTask] itself.
  *
- * This is an extension on [Project] rather than on the Maven exec task: the conventions
- * build does not depend on the maven-exec plugin and therefore can not see its task type,
- * and registering the import task needs the `TaskContainer` at configuration time, which
- * a `TaskProvider` can only reach by realizing itself.
+ * This is an extension on [Project] rather than on the invoker task: registering the
+ * import task needs the `TaskContainer` at configuration time, which a `TaskProvider` can
+ * only reach by realizing itself. The task is typed as [AbstractExecTask] and not as the
+ * maven-exec plugin's `MavenExec`, which the conventions build does not depend on and
+ * therefore can not see.
  *
  * @param invokerTask The task running the Maven Invoker Plugin.
  * @param invokerOutputDir That task's output directory.
  */
 fun Project.importMavenInvokerTestResults(
-    invokerTask: TaskProvider<out Task>,
+    invokerTask: TaskProvider<out AbstractExecTask<*>>,
     invokerOutputDir: Provider<Directory>
 ) {
     // 'reports' must match <reportsDirectory> in the maven-it pom. Both directories live
@@ -38,8 +39,19 @@ fun Project.importMavenInvokerTestResults(
     val normalizedReportsDir = invokerOutputDir.map { it.dir("develocity-junit-reports") }
 
     invokerTask.configure {
+        // Maven's exit code must not end the task before the reports are normalized
+        // below: a failing action skips every action after it, and a run that failed is
+        // precisely the run whose per-scenario reports are worth having in the Build
+        // Scan. The exit code is asserted in the last action instead, so the task still
+        // fails - and is therefore still not cached - for exactly the same runs as before.
+        isIgnoreExitValue = true
+        val invokerResult = executionResult
+
         doLast("normalize JUnit XML for Develocity") {
             normalizeInvokerReports(invokerReportsDir.get().asFile, normalizedReportsDir.get().asFile)
+        }
+        doLast("assert Maven Invoker exit code") {
+            invokerResult.get().assertNormalExitValue()
         }
     }
 

--- a/restrict-imports-enforcer-rule-maven-it/invoker-settings.xml
+++ b/restrict-imports-enforcer-rule-maven-it/invoker-settings.xml
@@ -12,9 +12,17 @@
 					<url>@localRepositoryUrl@</url>
 					<releases>
 						<enabled>true</enabled>
+						<!-- Maven's default is 'warn': a truncated artifact would be accepted with
+						     nothing but a warning, and only surface much later as a
+						     NoClassDefFoundError from inside a forked build. Fail on it instead. -->
+						<checksumPolicy>fail</checksumPolicy>
 					</releases>
 					<snapshots>
 						<enabled>true</enabled>
+						<!-- Maven's default is 'warn': a truncated artifact would be accepted with
+						     nothing but a warning, and only surface much later as a
+						     NoClassDefFoundError from inside a forked build. Fail on it instead. -->
+						<checksumPolicy>fail</checksumPolicy>
 					</snapshots>
 				</repository>
 			</repositories>
@@ -24,9 +32,11 @@
 					<url>@localRepositoryUrl@</url>
 					<releases>
 						<enabled>true</enabled>
+						<checksumPolicy>fail</checksumPolicy>
 					</releases>
 					<snapshots>
 						<enabled>true</enabled>
+						<checksumPolicy>fail</checksumPolicy>
 					</snapshots>
 				</pluginRepository>
 			</pluginRepositories>

--- a/restrict-imports-enforcer-rule-maven-it/pom.xml
+++ b/restrict-imports-enforcer-rule-maven-it/pom.xml
@@ -31,10 +31,26 @@
                 <executions>
                     <execution>
                         <goals>
+                            <!-- 'install' resolves extraArtifacts below into the local
+                                 repository before any integration test runs. -->
+                            <goal>install</goal>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                            <!-- Every scenario needs the enforcer plugin, and with a local
+                                 repository per leg they all need it at the same instant, on
+                                 an empty repository. Maven's local repository is not safe
+                                 for concurrent access across processes (MNG-2802), and the
+                                 fix for that - Resolver's named locks - needs resolver 1.7+,
+                                 while mavenMin 3.8.1 ships 1.6.2. Resolving these serially
+                                 up front is what keeps parallelThreads invoker JVMs from
+                                 racing to download the same artifacts. -->
+                            <extraArtifacts>
+                                <extraArtifact>org.apache.maven.plugins:maven-enforcer-plugin:${fromGradle.enforcer-api-version}</extraArtifact>
+                                <extraArtifact>org.apache.maven.enforcer:enforcer-api:${fromGradle.enforcer-api-version}</extraArtifact>
+                                <extraArtifact>org.apache.maven.enforcer:enforcer-rules:${fromGradle.enforcer-api-version}</extraArtifact>
+                            </extraArtifacts>
                             <junitPackageName>${fromGradle.test-id}</junitPackageName>
                             <reportsDirectory>${project.build.directory}/${fromGradle.output-dir}/reports</reportsDirectory>
                             <cloneProjectsTo>${project.build.directory}/${fromGradle.output-dir}/builds</cloneProjectsTo>

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -8,24 +8,17 @@ plugins {
 
 
 // TODO: fix duplication (see publishing-conventions)
+//
+// This holds the enforcer rule as Gradle publishes it, and nothing else of consequence:
+// it is the outer Maven's local repository, and invoker-settings.xml exposes it to the
+// integration tests as the 'local.central' repository so they can resolve the rule under
+// test. The artifacts those tests pull from Central land in a repository of their own,
+// per cross-version leg - see below.
 val m2Repository: Provider<Directory> = rootProject.layout.buildDirectory.dir("m2")
-
-// Maven downloads into this repository, and Gradle does not track what it writes there:
-// the publish task only ever removes its own outputs, so third-party artifacts survive
-// into the next build. In a reused CI workspace that is forever - which is how a
-// truncated enforcer-api jar kept every 'success' scenario failing for days, on a branch
-// whose sources were fine. Wiping it before anything publishes into it makes every build
-// start from the state a fresh workspace would have.
-val cleanInvokerLocalRepo = tasks.register<Delete>("cleanInvokerLocalRepo") {
-    description = "Deletes the Maven Invoker's local repository so no build inherits another build's artifacts"
-    delete(m2Repository)
-}
 
 // ProjectDependency.getDependencyProject() was removed in Gradle 9, resolve the project by its path instead
 val publishEnforcerRuleTask: Task? = project(projects.restrictImportsEnforcerRule.path)
     .tasks.findByName("publishMavenPublicationToLocalIntegrationTestsRepository")
-
-publishEnforcerRuleTask?.mustRunAfter(cleanInvokerLocalRepo)
 
 val functionalTest = tasks.register("functionalTest") {
     group = "verification"
@@ -58,7 +51,7 @@ val funcTestTasks = crossVersionTests
             group = "verification"
             notCompatibleWithConfigurationCache("Inherently not")
 
-            dependsOn(downloadTask, cleanInvokerLocalRepo)
+            dependsOn(downloadTask)
 
             val mavenExecTask = this
 
@@ -88,6 +81,22 @@ val funcTestTasks = crossVersionTests
             // to absolute paths baked into the Maven define map.
             outputs.cacheIf("inputs fully tracked with relative path sensitivity") { true }
 
+            // Every leg resolves into its own local repository, so a 3.8.1 leg can not
+            // leave an artifact behind that a 3.9.11 leg then silently passes on. It sits
+            // beside the task's output directory rather than inside it: outputs are opted
+            // into the build cache above, and ~10MB of third-party artifacts per leg do
+            // not belong in a cache entry.
+            //
+            // Nothing tracks this directory, so it is wiped here rather than left to
+            // Gradle. A local repository that outlives the build is how one truncated
+            // enforcer-api jar kept every 'success' scenario failing for days in a reused
+            // CI workspace: a checksum policy only applies while an artifact is being
+            // downloaded, so nothing ever rechecks what is already there.
+            val invokerLocalRepo = layout.buildDirectory.dir("m2-$taskName/repository")
+            doFirst("wipe the invoker's local repository") {
+                invokerLocalRepo.get().asFile.deleteRecursively()
+            }
+
             mavenDir = maven.mavenHome(mavenVersion)
             goals(setOf("verify"))
             options.showVersion(true)
@@ -105,7 +114,7 @@ val funcTestTasks = crossVersionTests
                     "fromGradle.enforcer-api-version" to enforcerVersion,
                     "fromGradle.invoker-plugin-version" to libs.versions.invokerPlugin.get(),
                     "fromGradle.integration-test-threads" to "2C",
-                    "fromGradle.localIntegrationTestRepo" to m2Repository.get().dir("repository").asFile.absolutePath
+                    "fromGradle.localIntegrationTestRepo" to invokerLocalRepo.get().asFile.absolutePath
                 )
             )
         }

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -113,7 +113,12 @@ val funcTestTasks = crossVersionTests
                     "fromGradle.output-dir" to taskName,
                     "fromGradle.enforcer-api-version" to enforcerVersion,
                     "fromGradle.invoker-plugin-version" to libs.versions.invokerPlugin.get(),
-                    "fromGradle.integration-test-threads" to "2C",
+                    // One invoker JVM per core, not two. Each scenario forks a JVM, so
+                    // 2C oversubscribes the agent, and the surplus threads mostly widen
+                    // the window in which they contend for the same local repository -
+                    // which is not safe for concurrent access across processes and can
+                    // not be locked on mavenMin (see extraArtifacts in the pom).
+                    "fromGradle.integration-test-threads" to "1C",
                     "fromGradle.localIntegrationTestRepo" to invokerLocalRepo.get().asFile.absolutePath
                 )
             )

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -18,6 +18,49 @@ val functionalTest = tasks.register("functionalTest") {
     group = "verification"
 }
 
+// TEMPORARY DIAGNOSTIC - remove once the CI func-test failures are understood.
+//
+// Every invoker sub-build on CI (Jenkins and GitHub Actions alike) dies with
+// NoClassDefFoundError: org/apache/maven/enforcer/rule/api/EnforcerRuleError, while the
+// plugin realm lists enforcer-api-3.6.1.jar under this very repository. A URLClassLoader
+// silently skips a URL whose file is absent or unreadable, which produces exactly that
+// error - so this dumps what is actually on disk, from inside the CI container, both
+// before Maven starts and after it has failed.
+fun dumpInvokerRepoState(label: String, repoRoot: File) {
+    fun log(line: String) = println("[IT-DIAG] $line")
+
+    log("=== $label ===")
+    log("user.name=${System.getProperty("user.name")} user.home=${System.getProperty("user.home")}")
+    log("repoRoot=$repoRoot exists=${repoRoot.isDirectory} totalFiles=${repoRoot.walkTopDown().count { it.isFile }}")
+
+    listOf("org/apache/maven/enforcer", "org/apache/maven/plugins/maven-enforcer-plugin").forEach { subPath ->
+        val dir = repoRoot.resolve(subPath)
+        log("-- $subPath exists=${dir.isDirectory}")
+        if (!dir.isDirectory) return@forEach
+
+        dir.walkTopDown().filter { it.isFile }.sortedBy { it.path }.forEach { file ->
+            val sha1 = runCatching {
+                java.security.MessageDigest.getInstance("SHA-1")
+                    .digest(file.readBytes())
+                    .joinToString("") { byte -> "%02x".format(byte) }
+            }.getOrElse { "unreadable: $it" }
+            log("   ${file.length()}\t$sha1\treadable=${file.canRead()}\t${file.relativeTo(repoRoot)}")
+
+            if (file.name.endsWith(".lastUpdated") || file.name == "_remote.repositories") {
+                file.readLines().filterNot { it.startsWith("#") || it.isBlank() }.forEach { log("      $it") }
+            }
+            if (file.name.startsWith("enforcer-api-") && file.name.endsWith(".jar")) {
+                val entries = runCatching {
+                    java.util.zip.ZipFile(file).use { zip ->
+                        zip.entries().asSequence().count { it.name.contains("EnforcerRuleError") }
+                    }
+                }
+                log("      EnforcerRuleError entries=${entries.getOrElse { "ZIP ERROR: $it" }}")
+            }
+        }
+    }
+}
+
 data class CrossVersionTest(val mavenVersion: Provider<String>, val enforcerVersion: Provider<String>)
 
 val crossVersionTests = listOf(libs.versions.mavenMin, libs.versions.mavenMax)
@@ -74,6 +117,13 @@ val funcTestTasks = crossVersionTests
             // same-machine rebuilds. Cross-machine cache hits may still miss due
             // to absolute paths baked into the Maven define map.
             outputs.cacheIf("inputs fully tracked with relative path sensitivity") { true }
+
+            // TEMPORARY DIAGNOSTIC - remove with dumpInvokerRepoState above.
+            // The 'after' dump runs before the exit-code assertion added by
+            // importMavenInvokerTestResults, so it is reached on a failing run too.
+            val invokerRepo = m2Repository.map { it.dir("repository").asFile }
+            doFirst("dump invoker repo state before") { dumpInvokerRepoState("$taskName BEFORE", invokerRepo.get()) }
+            doLast("dump invoker repo state after") { dumpInvokerRepoState("$taskName AFTER", invokerRepo.get()) }
 
             mavenDir = maven.mavenHome(mavenVersion)
             goals(setOf("verify"))

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -10,55 +10,25 @@ plugins {
 // TODO: fix duplication (see publishing-conventions)
 val m2Repository: Provider<Directory> = rootProject.layout.buildDirectory.dir("m2")
 
+// Maven downloads into this repository, and Gradle does not track what it writes there:
+// the publish task only ever removes its own outputs, so third-party artifacts survive
+// into the next build. In a reused CI workspace that is forever - which is how a
+// truncated enforcer-api jar kept every 'success' scenario failing for days, on a branch
+// whose sources were fine. Wiping it before anything publishes into it makes every build
+// start from the state a fresh workspace would have.
+val cleanInvokerLocalRepo = tasks.register<Delete>("cleanInvokerLocalRepo") {
+    description = "Deletes the Maven Invoker's local repository so no build inherits another build's artifacts"
+    delete(m2Repository)
+}
+
 // ProjectDependency.getDependencyProject() was removed in Gradle 9, resolve the project by its path instead
 val publishEnforcerRuleTask: Task? = project(projects.restrictImportsEnforcerRule.path)
     .tasks.findByName("publishMavenPublicationToLocalIntegrationTestsRepository")
 
+publishEnforcerRuleTask?.mustRunAfter(cleanInvokerLocalRepo)
+
 val functionalTest = tasks.register("functionalTest") {
     group = "verification"
-}
-
-// TEMPORARY DIAGNOSTIC - remove once the CI func-test failures are understood.
-//
-// Every invoker sub-build on CI (Jenkins and GitHub Actions alike) dies with
-// NoClassDefFoundError: org/apache/maven/enforcer/rule/api/EnforcerRuleError, while the
-// plugin realm lists enforcer-api-3.6.1.jar under this very repository. A URLClassLoader
-// silently skips a URL whose file is absent or unreadable, which produces exactly that
-// error - so this dumps what is actually on disk, from inside the CI container, both
-// before Maven starts and after it has failed.
-fun dumpInvokerRepoState(label: String, repoRoot: File) {
-    fun log(line: String) = println("[IT-DIAG] $line")
-
-    log("=== $label ===")
-    log("user.name=${System.getProperty("user.name")} user.home=${System.getProperty("user.home")}")
-    log("repoRoot=$repoRoot exists=${repoRoot.isDirectory} totalFiles=${repoRoot.walkTopDown().count { it.isFile }}")
-
-    listOf("org/apache/maven/enforcer", "org/apache/maven/plugins/maven-enforcer-plugin").forEach { subPath ->
-        val dir = repoRoot.resolve(subPath)
-        log("-- $subPath exists=${dir.isDirectory}")
-        if (!dir.isDirectory) return@forEach
-
-        dir.walkTopDown().filter { it.isFile }.sortedBy { it.path }.forEach { file ->
-            val sha1 = runCatching {
-                java.security.MessageDigest.getInstance("SHA-1")
-                    .digest(file.readBytes())
-                    .joinToString("") { byte -> "%02x".format(byte) }
-            }.getOrElse { "unreadable: $it" }
-            log("   ${file.length()}\t$sha1\treadable=${file.canRead()}\t${file.relativeTo(repoRoot)}")
-
-            if (file.name.endsWith(".lastUpdated") || file.name == "_remote.repositories") {
-                file.readLines().filterNot { it.startsWith("#") || it.isBlank() }.forEach { log("      $it") }
-            }
-            if (file.name.startsWith("enforcer-api-") && file.name.endsWith(".jar")) {
-                val entries = runCatching {
-                    java.util.zip.ZipFile(file).use { zip ->
-                        zip.entries().asSequence().count { it.name.contains("EnforcerRuleError") }
-                    }
-                }
-                log("      EnforcerRuleError entries=${entries.getOrElse { "ZIP ERROR: $it" }}")
-            }
-        }
-    }
 }
 
 data class CrossVersionTest(val mavenVersion: Provider<String>, val enforcerVersion: Provider<String>)
@@ -88,7 +58,7 @@ val funcTestTasks = crossVersionTests
             group = "verification"
             notCompatibleWithConfigurationCache("Inherently not")
 
-            dependsOn(downloadTask)
+            dependsOn(downloadTask, cleanInvokerLocalRepo)
 
             val mavenExecTask = this
 
@@ -118,18 +88,17 @@ val funcTestTasks = crossVersionTests
             // to absolute paths baked into the Maven define map.
             outputs.cacheIf("inputs fully tracked with relative path sensitivity") { true }
 
-            // TEMPORARY DIAGNOSTIC - remove with dumpInvokerRepoState above.
-            // The 'after' dump runs before the exit-code assertion added by
-            // importMavenInvokerTestResults, so it is reached on a failing run too.
-            val invokerRepo = m2Repository.map { it.dir("repository").asFile }
-            doFirst("dump invoker repo state before") { dumpInvokerRepoState("$taskName BEFORE", invokerRepo.get()) }
-            doLast("dump invoker repo state after") { dumpInvokerRepoState("$taskName AFTER", invokerRepo.get()) }
-
             mavenDir = maven.mavenHome(mavenVersion)
             goals(setOf("verify"))
             options.showVersion(true)
             define(
                 mapOf(
+                    // Without this the outer Maven resolves into ~/.m2, which on the CI
+                    // agent is a bind mount shared live with every concurrently running
+                    // build - and invoker-settings.xml then exposes that directory to all
+                    // 16 invoker JVMs as the 'local.central' repository. Pointing it at the
+                    // project-local repository keeps the integration tests off it entirely.
+                    "maven.repo.local" to m2Repository.get().dir("repository").asFile.absolutePath,
                     "revision" to project.version.toString(),
                     "fromGradle.test-id" to "maven.invoker.it.maven_$safeMavenVersion.enforcer_$safeEnforcerVersion",
                     "fromGradle.output-dir" to taskName,


### PR DESCRIPTION
## Why the func tests were failing

Every invoker sub-build died before the rule under test was ever evaluated:

```
[INFO] --- maven-enforcer-plugin:3.6.1:enforce (default-cli) @ success1 ---
[WARNING] Error injecting: org.apache.maven.plugins.enforcer.EnforceMojo
java.lang.NoClassDefFoundError: org/apache/maven/enforcer/rule/api/EnforcerRuleError
```

So every scenario with `invoker.buildResult=success` failed and every `fail-*` scenario
passed vacuously — the 18-of-31 shape seen on CI.

`build/m2/repository` was both the publishing repository and the invoker's
`<localRepositoryPath>`. Gradle only removes a task's own outputs, so Maven's downloads
there were untracked and survived into the next build — in a reused CI workspace,
indefinitely. `invoker-settings.xml` then exposed `@localRepositoryUrl@` — the *outer*
Maven's local repository, **not** `<localRepositoryPath>` — as the `local.central`
repository, ahead of Central. On the Jenkins agent that is `~/.m2`, a bind mount shared
live with every concurrently running build, and Maven's default checksum policy is `warn`,
so a half-written read is accepted silently. The bad copy of `enforcer-api` landed in the
workspace repository and stayed there.

Confirmed by building develop's exact commit (`88879d0`, not one byte changed) in a fresh
workspace on the same agent: **SUCCESS**, while `develop` on its old workspace failed nine
times running.

## Changes

- Every cross-version leg resolves into **its own** local repository, wiped per run, so
  nothing survives a build and the legs cannot contaminate each other. It sits beside the
  task's output directory, not inside it: outputs are opted into the build cache and
  ~10MB of third-party artifacts per leg do not belong in a cache entry.
- The invoker's `install` goal pre-resolves the enforcer artifacts **serially** before any
  test runs, so the parallel phase does not race for them.
- `-Dmaven.repo.local` points the outer Maven at the project-local repository, so the
  shared agent-wide `~/.m2` is never used by the integration tests at all.
- `<checksumPolicy>fail</checksumPolicy>` makes a truncated artifact fail where it happens,
  rather than surfacing as a class-loading error inside a forked build days later.
- `parallelThreads` drops from `2C` to `1C` — every scenario forks its own Maven JVM, so
  `2C` oversubscribed the agent.

## Effect on CI run times

The same fixes that make this correct also make it much faster, because the shared
repository was a contention point as well as a corruption point. All figures are the
`functionalTest` build, with every leg verified as `executed_cacheable` — no build-cache
hits:

| commit | change | GitHub Actions | Jenkins |
| --- | --- | --- | --- |
| `4d9a77b` | before this work | 231s | 371s |
| `c891644` | shared repository, wiped per build | 234s | 416s |
| `c69ddb7` | a repository per leg + pre-warm | 236s | 224s |
| `2947afc` | `1C` | 234s | **185s** |

**Jenkins halves, 371s to 185s.** GitHub Actions is flat throughout, within noise. The
entire gain is on the contended agent: its runners are ephemeral and never contended
enough for any of this to register, while on Jenkins 16 invoker JVMs were competing for
one repository on slow storage. That also explains the per-scenario medians on the
unchanged code — 36.5s on Jenkins against 8.2s on GitHub Actions, despite twice the cores.

## Why a repository per leg

The legs used to share one repository, which was also the repository Gradle publishes the
rule into — so wiping it meant ordering the wipe against the publish task from another
project. A repository per leg removes that coupling entirely: each wipes its own in a
`doFirst`, and the published rule stays in `build/m2`, reached through `local.central` as
before. It also stops a 3.8.1 leg leaving an artifact behind that a 3.9.11 leg then
silently passes on, which for a cross-version matrix is a false pass waiting to happen.

Measured cold on a developer machine, four legs: 50s shared, 59s per leg, 40MB against
38MB on disk. Cheaper than it looks because the legs need largely different artifacts —
each needs ~40 jars, the union is 49, and only 32 are common.

## Why pre-warm

Isolation means every leg now starts empty, so all four reach for the enforcer plugin at
once rather than only the first. Maven's local repository is not safe for concurrent
access across processes ([MNG-2802](https://issues.apache.org/jira/browse/MNG-2802)), and
the fix — [Resolver's named locks](https://maven.apache.org/resolver/maven-resolver-named-locks/index.html),
`-Daether.syncContext.named.factory=file-lock` — needs resolver 1.7+, while `mavenMin`
3.8.1 ships 1.6.2 with no `maven-resolver-named-locks` on its classpath at all.

So the `install` goal resolves those artifacts serially up front. Verified from the build
log: **41 enforcer artifacts fetched during `install`, none during the parallel phase**,
where the invoker JVMs would otherwise contend for the same files. Costs ~1s.

Note this is inert without the `install` goal binding — as a plugin-level parameter on
`integration-test`/`verify` it is silently ignored, which a probe artifact confirmed.

## Reporting the failures at all

Separately, the JUnit XML import added in #287 only ever reported on runs that *passed*.
Normalization was a `doLast` on the `MavenExec` task, and Gradle skips every remaining
action once one throws, so Maven's non-zero exit ended the task before the reports were
normalized. The import task is a finalizer and does run after a failed task, but it found
an empty directory — leaving the Build Scan of a failing run with no test data at all,
which is the one run whose per-scenario logs are worth having.

The exit value is now ignored during the exec action and asserted in a trailing `doLast`;
the task still fails, and is still not cached, for exactly the same runs. Checked in both
directions by deliberately breaking `success1`: the task fails, 31 reports are normalized,
and the scan carries 31 tests (30 passed, 1 failed) with the scenario's `build.log` in the
test output.

## Verification

- Locally, `functionalTest quickCheck build-logic:check --no-build-cache` from a cold
  repository: all four legs `Passed: 31, Failed: 0`.
- On Jenkins and GitHub Actions, green on every commit in the table above, with all four
  legs genuinely executed.

## Note on the currently red branches

`develop`, `burmese`, `gradle-docs`, `readme-snippets`, `sicilians` and PR-289 each still
hold a poisoned `build/m2` in their long-lived Jenkins workspace. They heal on the first
build that carries these commits, so no manual workspace surgery is needed — but `develop`
needs this merged into it too, not just into `master`.
