### PR TITLE
Backport the Maven invoker func-test fixes to develop

### DIFF
--- a/build-logic/conventions/src/main/kotlin/MavenInvokerTestReporting.kt
+++ b/build-logic/conventions/src/main/kotlin/MavenInvokerTestReporting.kt
@@ -1,0 +1,98 @@
+import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports
+import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import java.io.File
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+/**
+ * Reports the results of a Maven Invoker Plugin run as tests in the Build Scan.
+ *
+ * The invoker plugin already writes a JUnit XML report per integration test (see
+ * `<writeJunitReport>` in the maven-it pom), so all that is needed is to hand those
+ * reports to Develocity. This registers a finalizer of [invokerTask] which imports them
+ * as real test executions, attributed to [invokerTask] itself.
+ *
+ * This is an extension on [Project] rather than on the Maven exec task: the conventions
+ * build does not depend on the maven-exec plugin and therefore can not see its task type,
+ * and registering the import task needs the `TaskContainer` at configuration time, which
+ * a `TaskProvider` can only reach by realizing itself.
+ *
+ * @param invokerTask The task running the Maven Invoker Plugin.
+ * @param invokerOutputDir That task's output directory.
+ */
+fun Project.importMavenInvokerTestResults(
+    invokerTask: TaskProvider<out Task>,
+    invokerOutputDir: Provider<Directory>
+) {
+    // 'reports' must match <reportsDirectory> in the maven-it pom. Both directories live
+    // inside the invoker task's output directory, so the normalized copies are part of
+    // its build cache entry and survive a cache hit.
+    val invokerReportsDir = invokerOutputDir.map { it.dir("reports") }
+    val normalizedReportsDir = invokerOutputDir.map { it.dir("develocity-junit-reports") }
+
+    invokerTask.configure {
+        doLast("normalize JUnit XML for Develocity") {
+            normalizeInvokerReports(invokerReportsDir.get().asFile, normalizedReportsDir.get().asFile)
+        }
+    }
+
+    ImportJUnitXmlReports.register(tasks, invokerTask, JUnitXmlDialect.GENERIC).configure {
+        // setFrom replaces the default, which is the whole output file tree of the
+        // reference task: that would also feed the parser the invoker's own BUILD-*.xml
+        // (a <build-job> format, not JUnit XML) and the cloned projects under builds/.
+        reports.setFrom(normalizedReportsDir.map { it.asFileTree.matching { include("TEST-*.xml") } })
+    }
+}
+
+/**
+ * Writes copies of the invoker's JUnit XML reports that Develocity's parser accepts.
+ *
+ * The originals are left untouched, so the invoker's own reports stay as it wrote them.
+ */
+private fun normalizeInvokerReports(invokerReportsDir: File, normalizedReportsDir: File) {
+    normalizedReportsDir.deleteRecursively()
+    normalizedReportsDir.mkdirs()
+
+    invokerReportsDir
+        .listFiles { file -> file.name.startsWith("TEST-") && file.name.endsWith(".xml") }
+        .orEmpty()
+        .forEach { report ->
+            normalizedReportsDir.resolve(report.name).writeText(withTimestamp(report))
+        }
+}
+
+private val testSuiteDuration = Regex("<testsuite\\b[^>]*\\btime=\"([^\"]*)\"")
+
+/**
+ * Adds the 'timestamp' attribute that the Maven Invoker Plugin never writes on
+ * `<testsuite>` (still true as of 3.10.1), but which Develocity's JUnit XML parser
+ * requires, aborting the whole import without it.
+ */
+private fun withTimestamp(report: File): String {
+    val xml = report.readText()
+    // Only look at the opening <testsuite> tag: <system-out> embeds the whole Maven build
+    // log, which may well contain 'timestamp=' itself.
+    if (xml.substringBefore('>').contains("timestamp=")) {
+        return xml
+    }
+
+    // The invoker writes each report once its build job has finished, so the file's
+    // modification time minus the recorded duration approximates when that job started.
+    // There is no better source: the XML records no start time.
+    val durationMillis = testSuiteDuration.find(xml)
+        ?.groupValues?.get(1)?.toDoubleOrNull()
+        ?.times(1000)?.toLong()
+        ?: 0L
+    val startedAt = Instant.ofEpochMilli(report.lastModified()).minusMillis(durationMillis)
+    val timestamp = OffsetDateTime.ofInstant(startedAt, ZoneId.systemDefault())
+        .truncatedTo(ChronoUnit.SECONDS)
+
+    return xml.replaceFirst("<testsuite ", "<testsuite timestamp=\"$timestamp\" ")
+}

--- a/build-logic/conventions/src/main/kotlin/MavenInvokerTestReporting.kt
+++ b/build-logic/conventions/src/main/kotlin/MavenInvokerTestReporting.kt
@@ -1,9 +1,9 @@
 import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports
 import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.AbstractExecTask
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
 import java.time.Instant
@@ -19,16 +19,17 @@ import java.time.temporal.ChronoUnit
  * reports to Develocity. This registers a finalizer of [invokerTask] which imports them
  * as real test executions, attributed to [invokerTask] itself.
  *
- * This is an extension on [Project] rather than on the Maven exec task: the conventions
- * build does not depend on the maven-exec plugin and therefore can not see its task type,
- * and registering the import task needs the `TaskContainer` at configuration time, which
- * a `TaskProvider` can only reach by realizing itself.
+ * This is an extension on [Project] rather than on the invoker task: registering the
+ * import task needs the `TaskContainer` at configuration time, which a `TaskProvider` can
+ * only reach by realizing itself. The task is typed as [AbstractExecTask] and not as the
+ * maven-exec plugin's `MavenExec`, which the conventions build does not depend on and
+ * therefore can not see.
  *
  * @param invokerTask The task running the Maven Invoker Plugin.
  * @param invokerOutputDir That task's output directory.
  */
 fun Project.importMavenInvokerTestResults(
-    invokerTask: TaskProvider<out Task>,
+    invokerTask: TaskProvider<out AbstractExecTask<*>>,
     invokerOutputDir: Provider<Directory>
 ) {
     // 'reports' must match <reportsDirectory> in the maven-it pom. Both directories live
@@ -38,8 +39,19 @@ fun Project.importMavenInvokerTestResults(
     val normalizedReportsDir = invokerOutputDir.map { it.dir("develocity-junit-reports") }
 
     invokerTask.configure {
+        // Maven's exit code must not end the task before the reports are normalized
+        // below: a failing action skips every action after it, and a run that failed is
+        // precisely the run whose per-scenario reports are worth having in the Build
+        // Scan. The exit code is asserted in the last action instead, so the task still
+        // fails - and is therefore still not cached - for exactly the same runs as before.
+        isIgnoreExitValue = true
+        val invokerResult = executionResult
+
         doLast("normalize JUnit XML for Develocity") {
             normalizeInvokerReports(invokerReportsDir.get().asFile, normalizedReportsDir.get().asFile)
+        }
+        doLast("assert Maven Invoker exit code") {
+            invokerResult.get().assertNormalExitValue()
         }
     }
 

--- a/restrict-imports-enforcer-rule-maven-it/invoker-settings.xml
+++ b/restrict-imports-enforcer-rule-maven-it/invoker-settings.xml
@@ -12,9 +12,17 @@
 					<url>@localRepositoryUrl@</url>
 					<releases>
 						<enabled>true</enabled>
+						<!-- Maven's default is 'warn': a truncated artifact would be accepted with
+						     nothing but a warning, and only surface much later as a
+						     NoClassDefFoundError from inside a forked build. Fail on it instead. -->
+						<checksumPolicy>fail</checksumPolicy>
 					</releases>
 					<snapshots>
 						<enabled>true</enabled>
+						<!-- Maven's default is 'warn': a truncated artifact would be accepted with
+						     nothing but a warning, and only surface much later as a
+						     NoClassDefFoundError from inside a forked build. Fail on it instead. -->
+						<checksumPolicy>fail</checksumPolicy>
 					</snapshots>
 				</repository>
 			</repositories>
@@ -24,9 +32,11 @@
 					<url>@localRepositoryUrl@</url>
 					<releases>
 						<enabled>true</enabled>
+						<checksumPolicy>fail</checksumPolicy>
 					</releases>
 					<snapshots>
 						<enabled>true</enabled>
+						<checksumPolicy>fail</checksumPolicy>
 					</snapshots>
 				</pluginRepository>
 			</pluginRepositories>

--- a/restrict-imports-enforcer-rule-maven-it/pom.xml
+++ b/restrict-imports-enforcer-rule-maven-it/pom.xml
@@ -31,10 +31,26 @@
                 <executions>
                     <execution>
                         <goals>
+                            <!-- 'install' resolves extraArtifacts below into the local
+                                 repository before any integration test runs. -->
+                            <goal>install</goal>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                            <!-- Every scenario needs the enforcer plugin, and with a local
+                                 repository per leg they all need it at the same instant, on
+                                 an empty repository. Maven's local repository is not safe
+                                 for concurrent access across processes (MNG-2802), and the
+                                 fix for that - Resolver's named locks - needs resolver 1.7+,
+                                 while mavenMin 3.8.1 ships 1.6.2. Resolving these serially
+                                 up front is what keeps parallelThreads invoker JVMs from
+                                 racing to download the same artifacts. -->
+                            <extraArtifacts>
+                                <extraArtifact>org.apache.maven.plugins:maven-enforcer-plugin:${fromGradle.enforcer-api-version}</extraArtifact>
+                                <extraArtifact>org.apache.maven.enforcer:enforcer-api:${fromGradle.enforcer-api-version}</extraArtifact>
+                                <extraArtifact>org.apache.maven.enforcer:enforcer-rules:${fromGradle.enforcer-api-version}</extraArtifact>
+                            </extraArtifacts>
                             <junitPackageName>${fromGradle.test-id}</junitPackageName>
                             <reportsDirectory>${project.build.directory}/${fromGradle.output-dir}/reports</reportsDirectory>
                             <cloneProjectsTo>${project.build.directory}/${fromGradle.output-dir}/builds</cloneProjectsTo>

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -8,24 +8,17 @@ plugins {
 
 
 // TODO: fix duplication (see publishing-conventions)
+//
+// This holds the enforcer rule as Gradle publishes it, and nothing else of consequence:
+// it is the outer Maven's local repository, and invoker-settings.xml exposes it to the
+// integration tests as the 'local.central' repository so they can resolve the rule under
+// test. The artifacts those tests pull from Central land in a repository of their own,
+// per cross-version leg - see below.
 val m2Repository: Provider<Directory> = rootProject.layout.buildDirectory.dir("m2")
-
-// Maven downloads into this repository, and Gradle does not track what it writes there:
-// the publish task only ever removes its own outputs, so third-party artifacts survive
-// into the next build. In a reused CI workspace that is forever - which is how a
-// truncated enforcer-api jar kept every 'success' scenario failing for days, on a branch
-// whose sources were fine. Wiping it before anything publishes into it makes every build
-// start from the state a fresh workspace would have.
-val cleanInvokerLocalRepo = tasks.register<Delete>("cleanInvokerLocalRepo") {
-    description = "Deletes the Maven Invoker's local repository so no build inherits another build's artifacts"
-    delete(m2Repository)
-}
 
 // ProjectDependency.getDependencyProject() was removed in Gradle 9, resolve the project by its path instead
 val publishEnforcerRuleTask: Task? = project(projects.restrictImportsEnforcerRule.path)
     .tasks.findByName("publishMavenPublicationToLocalIntegrationTestsRepository")
-
-publishEnforcerRuleTask?.mustRunAfter(cleanInvokerLocalRepo)
 
 val functionalTest = tasks.register("functionalTest") {
     group = "verification"
@@ -58,7 +51,7 @@ val funcTestTasks = crossVersionTests
             group = "verification"
             notCompatibleWithConfigurationCache("Inherently not")
 
-            dependsOn(downloadTask, cleanInvokerLocalRepo)
+            dependsOn(downloadTask)
 
             val mavenExecTask = this
 
@@ -88,6 +81,22 @@ val funcTestTasks = crossVersionTests
             // to absolute paths baked into the Maven define map.
             outputs.cacheIf("inputs fully tracked with relative path sensitivity") { true }
 
+            // Every leg resolves into its own local repository, so a 3.8.1 leg can not
+            // leave an artifact behind that a 3.9.11 leg then silently passes on. It sits
+            // beside the task's output directory rather than inside it: outputs are opted
+            // into the build cache above, and ~10MB of third-party artifacts per leg do
+            // not belong in a cache entry.
+            //
+            // Nothing tracks this directory, so it is wiped here rather than left to
+            // Gradle. A local repository that outlives the build is how one truncated
+            // enforcer-api jar kept every 'success' scenario failing for days in a reused
+            // CI workspace: a checksum policy only applies while an artifact is being
+            // downloaded, so nothing ever rechecks what is already there.
+            val invokerLocalRepo = layout.buildDirectory.dir("m2-$taskName/repository")
+            doFirst("wipe the invoker's local repository") {
+                invokerLocalRepo.get().asFile.deleteRecursively()
+            }
+
             mavenDir = maven.mavenHome(mavenVersion)
             goals(setOf("verify"))
             options.showVersion(true)
@@ -105,7 +114,7 @@ val funcTestTasks = crossVersionTests
                     "fromGradle.enforcer-api-version" to enforcerVersion,
                     "fromGradle.invoker-plugin-version" to libs.versions.invokerPlugin.get(),
                     "fromGradle.integration-test-threads" to "2C",
-                    "fromGradle.localIntegrationTestRepo" to m2Repository.get().dir("repository").asFile.absolutePath
+                    "fromGradle.localIntegrationTestRepo" to invokerLocalRepo.get().asFile.absolutePath
                 )
             )
         }

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -1,4 +1,10 @@
 import com.github.dkorotych.gradle.maven.exec.MavenExec
+import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports
+import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 
 plugins {
     id("build-logic.base")
@@ -36,7 +42,14 @@ val funcTestTasks = crossVersionTests
 
         val downloadTask = maven.download(mavenVersion)
 
-        tasks.register<MavenExec>("funcTestMaven_${safeMavenVersion}_enforcer_${safeEnforcerVersion}") {
+        val taskName = "funcTestMaven_${safeMavenVersion}_enforcer_${safeEnforcerVersion}"
+
+        // JUnit XML as written by the Maven Invoker Plugin, and the copies of it that are
+        // normalized for Develocity (see the doLast block below).
+        val invokerReportsDir = layout.buildDirectory.dir("$taskName/reports")
+        val develocityReportsDir = layout.buildDirectory.dir("$taskName/develocity-junit-reports")
+
+        val funcTestTask = tasks.register<MavenExec>(taskName) {
             description = "Executes Maven Enforcer Plugin integration tests"
             group = "verification"
             notCompatibleWithConfigurationCache("Inherently not")
@@ -78,7 +91,7 @@ val funcTestTasks = crossVersionTests
             define(
                 mapOf(
                     "revision" to project.version.toString(),
-                    "fromGradle.test-id" to "maven.invoker.it._$safeEnforcerVersion",
+                    "fromGradle.test-id" to "maven.invoker.it.maven_$safeMavenVersion.enforcer_$safeEnforcerVersion",
                     "fromGradle.output-dir" to outputDir,
                     "fromGradle.enforcer-api-version" to enforcerVersion,
                     "fromGradle.invoker-plugin-version" to libs.versions.invokerPlugin.get(),
@@ -86,7 +99,60 @@ val funcTestTasks = crossVersionTests
                     "fromGradle.localIntegrationTestRepo" to m2Repository.get().dir("repository").asFile.absolutePath
                 )
             )
+
+            doLast("normalize JUnit XML for Develocity") {
+                // The Maven Invoker Plugin never writes the 'timestamp' attribute on
+                // <testsuite> (still true as of 3.10.1), but Develocity's JUnit XML parser
+                // requires it and aborts the whole import without it. Write normalized
+                // copies rather than editing the originals, so the invoker's own reports
+                // stay untouched. Both directories live inside this task's output
+                // directory, so the copies survive a build cache hit as well.
+                val reportsDir = invokerReportsDir.get().asFile
+                val normalizedDir = develocityReportsDir.get().asFile
+                normalizedDir.deleteRecursively()
+                normalizedDir.mkdirs()
+
+                // The invoker writes each report once its build job has finished, so the
+                // file's modification time minus the recorded duration approximates when
+                // that job started. There is no better source: the XML records no start.
+                val durationPattern = Regex("<testsuite\\b[^>]*\\btime=\"([^\"]*)\"")
+
+                reportsDir.listFiles { file -> file.name.startsWith("TEST-") && file.name.endsWith(".xml") }
+                    .orEmpty()
+                    .forEach { report ->
+                        val xml = report.readText()
+                        // Only look at the opening <testsuite> tag: <system-out> embeds the
+                        // whole Maven build log, which may well contain 'timestamp=' itself.
+                        val normalized = if (xml.substringBefore('>').contains("timestamp=")) {
+                            xml
+                        } else {
+                            val durationMillis = durationPattern.find(xml)
+                                ?.groupValues?.get(1)?.toDoubleOrNull()
+                                ?.times(1000)?.toLong()
+                                ?: 0L
+                            val startedAt = Instant.ofEpochMilli(report.lastModified())
+                                .minusMillis(durationMillis)
+                            val timestamp = OffsetDateTime.ofInstant(startedAt, ZoneId.systemDefault())
+                                .truncatedTo(ChronoUnit.SECONDS)
+                            xml.replaceFirst("<testsuite ", """<testsuite timestamp="$timestamp" """)
+                        }
+                        normalizedDir.resolve(report.name).writeText(normalized)
+                    }
+            }
         }
+
+        // Report the Maven Invoker results as tests in the Build Scan. The invoker plugin
+        // already writes JUnit XML (see <writeJunitReport> in pom.xml); this registers a
+        // finalizer task that hands those reports to Develocity, attributed to the
+        // MavenExec task that produced them.
+        ImportJUnitXmlReports.register(tasks, funcTestTask, JUnitXmlDialect.GENERIC).configure {
+            // setFrom replaces the default, which is the task's entire output file tree:
+            // that would also feed the parser the invoker's own BUILD-*.xml (a <build-job>
+            // format, not JUnit XML) and the cloned projects under builds/.
+            reports.setFrom(develocityReportsDir.map { it.asFileTree.matching { include("TEST-*.xml") } })
+        }
+
+        funcTestTask
     }
 
 funcTestTasks.forEach {

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -113,7 +113,12 @@ val funcTestTasks = crossVersionTests
                     "fromGradle.output-dir" to taskName,
                     "fromGradle.enforcer-api-version" to enforcerVersion,
                     "fromGradle.invoker-plugin-version" to libs.versions.invokerPlugin.get(),
-                    "fromGradle.integration-test-threads" to "2C",
+                    // One invoker JVM per core, not two. Each scenario forks a JVM, so
+                    // 2C oversubscribes the agent, and the surplus threads mostly widen
+                    // the window in which they contend for the same local repository -
+                    // which is not safe for concurrent access across processes and can
+                    // not be locked on mavenMin (see extraArtifacts in the pom).
+                    "fromGradle.integration-test-threads" to "1C",
                     "fromGradle.localIntegrationTestRepo" to invokerLocalRepo.get().asFile.absolutePath
                 )
             )

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -1,10 +1,4 @@
 import com.github.dkorotych.gradle.maven.exec.MavenExec
-import com.gradle.develocity.agent.gradle.test.ImportJUnitXmlReports
-import com.gradle.develocity.agent.gradle.test.JUnitXmlDialect
-import java.time.Instant
-import java.time.OffsetDateTime
-import java.time.ZoneId
-import java.time.temporal.ChronoUnit
 
 plugins {
     id("build-logic.base")
@@ -44,10 +38,7 @@ val funcTestTasks = crossVersionTests
 
         val taskName = "funcTestMaven_${safeMavenVersion}_enforcer_${safeEnforcerVersion}"
 
-        // JUnit XML as written by the Maven Invoker Plugin, and the copies of it that are
-        // normalized for Develocity (see the doLast block below).
-        val invokerReportsDir = layout.buildDirectory.dir("$taskName/reports")
-        val develocityReportsDir = layout.buildDirectory.dir("$taskName/develocity-junit-reports")
+        val taskOutputDir = layout.buildDirectory.dir(taskName)
 
         val funcTestTask = tasks.register<MavenExec>(taskName) {
             description = "Executes Maven Enforcer Plugin integration tests"
@@ -64,7 +55,6 @@ val funcTestTasks = crossVersionTests
                 mavenExecTask.inputs.files(publishTask.project.tasks.withType<JavaCompile>())
             }
 
-            val outputDir = mavenExecTask.name
             inputs.files(layout.projectDirectory.dir("src/it/maven"))
                 .withPropertyName("mavenIntegrationTestSources")
                 .withPathSensitivity(PathSensitivity.RELATIVE)
@@ -74,7 +64,7 @@ val funcTestTasks = crossVersionTests
             inputs.files(layout.projectDirectory.file("pom.xml"))
                 .withPropertyName("mavenItPom")
                 .withPathSensitivity(PathSensitivity.RELATIVE)
-            outputs.dir(layout.buildDirectory.file(outputDir))
+            outputs.dir(taskOutputDir)
 
             // Opt this task into the build cache. The MavenExec task type from the
             // 'com.github.dkorotych.gradle-maven-exec' plugin is not annotated
@@ -92,65 +82,17 @@ val funcTestTasks = crossVersionTests
                 mapOf(
                     "revision" to project.version.toString(),
                     "fromGradle.test-id" to "maven.invoker.it.maven_$safeMavenVersion.enforcer_$safeEnforcerVersion",
-                    "fromGradle.output-dir" to outputDir,
+                    "fromGradle.output-dir" to taskName,
                     "fromGradle.enforcer-api-version" to enforcerVersion,
                     "fromGradle.invoker-plugin-version" to libs.versions.invokerPlugin.get(),
                     "fromGradle.integration-test-threads" to "2C",
                     "fromGradle.localIntegrationTestRepo" to m2Repository.get().dir("repository").asFile.absolutePath
                 )
             )
-
-            doLast("normalize JUnit XML for Develocity") {
-                // The Maven Invoker Plugin never writes the 'timestamp' attribute on
-                // <testsuite> (still true as of 3.10.1), but Develocity's JUnit XML parser
-                // requires it and aborts the whole import without it. Write normalized
-                // copies rather than editing the originals, so the invoker's own reports
-                // stay untouched. Both directories live inside this task's output
-                // directory, so the copies survive a build cache hit as well.
-                val reportsDir = invokerReportsDir.get().asFile
-                val normalizedDir = develocityReportsDir.get().asFile
-                normalizedDir.deleteRecursively()
-                normalizedDir.mkdirs()
-
-                // The invoker writes each report once its build job has finished, so the
-                // file's modification time minus the recorded duration approximates when
-                // that job started. There is no better source: the XML records no start.
-                val durationPattern = Regex("<testsuite\\b[^>]*\\btime=\"([^\"]*)\"")
-
-                reportsDir.listFiles { file -> file.name.startsWith("TEST-") && file.name.endsWith(".xml") }
-                    .orEmpty()
-                    .forEach { report ->
-                        val xml = report.readText()
-                        // Only look at the opening <testsuite> tag: <system-out> embeds the
-                        // whole Maven build log, which may well contain 'timestamp=' itself.
-                        val normalized = if (xml.substringBefore('>').contains("timestamp=")) {
-                            xml
-                        } else {
-                            val durationMillis = durationPattern.find(xml)
-                                ?.groupValues?.get(1)?.toDoubleOrNull()
-                                ?.times(1000)?.toLong()
-                                ?: 0L
-                            val startedAt = Instant.ofEpochMilli(report.lastModified())
-                                .minusMillis(durationMillis)
-                            val timestamp = OffsetDateTime.ofInstant(startedAt, ZoneId.systemDefault())
-                                .truncatedTo(ChronoUnit.SECONDS)
-                            xml.replaceFirst("<testsuite ", """<testsuite timestamp="$timestamp" """)
-                        }
-                        normalizedDir.resolve(report.name).writeText(normalized)
-                    }
-            }
         }
 
-        // Report the Maven Invoker results as tests in the Build Scan. The invoker plugin
-        // already writes JUnit XML (see <writeJunitReport> in pom.xml); this registers a
-        // finalizer task that hands those reports to Develocity, attributed to the
-        // MavenExec task that produced them.
-        ImportJUnitXmlReports.register(tasks, funcTestTask, JUnitXmlDialect.GENERIC).configure {
-            // setFrom replaces the default, which is the task's entire output file tree:
-            // that would also feed the parser the invoker's own BUILD-*.xml (a <build-job>
-            // format, not JUnit XML) and the cloned projects under builds/.
-            reports.setFrom(develocityReportsDir.map { it.asFileTree.matching { include("TEST-*.xml") } })
-        }
+        // Report the Maven Invoker results as tests in the Build Scan.
+        importMavenInvokerTestResults(funcTestTask, taskOutputDir)
 
         funcTestTask
     }

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -18,6 +18,49 @@ val functionalTest = tasks.register("functionalTest") {
     group = "verification"
 }
 
+// TEMPORARY DIAGNOSTIC - remove once the CI func-test failures are understood.
+//
+// Every invoker sub-build on CI (Jenkins and GitHub Actions alike) dies with
+// NoClassDefFoundError: org/apache/maven/enforcer/rule/api/EnforcerRuleError, while the
+// plugin realm lists enforcer-api-3.6.1.jar under this very repository. A URLClassLoader
+// silently skips a URL whose file is absent or unreadable, which produces exactly that
+// error - so this dumps what is actually on disk, from inside the CI container, both
+// before Maven starts and after it has failed.
+fun dumpInvokerRepoState(label: String, repoRoot: File) {
+    fun log(line: String) = println("[IT-DIAG] $line")
+
+    log("=== $label ===")
+    log("user.name=${System.getProperty("user.name")} user.home=${System.getProperty("user.home")}")
+    log("repoRoot=$repoRoot exists=${repoRoot.isDirectory} totalFiles=${repoRoot.walkTopDown().count { it.isFile }}")
+
+    listOf("org/apache/maven/enforcer", "org/apache/maven/plugins/maven-enforcer-plugin").forEach { subPath ->
+        val dir = repoRoot.resolve(subPath)
+        log("-- $subPath exists=${dir.isDirectory}")
+        if (!dir.isDirectory) return@forEach
+
+        dir.walkTopDown().filter { it.isFile }.sortedBy { it.path }.forEach { file ->
+            val sha1 = runCatching {
+                java.security.MessageDigest.getInstance("SHA-1")
+                    .digest(file.readBytes())
+                    .joinToString("") { byte -> "%02x".format(byte) }
+            }.getOrElse { "unreadable: $it" }
+            log("   ${file.length()}\t$sha1\treadable=${file.canRead()}\t${file.relativeTo(repoRoot)}")
+
+            if (file.name.endsWith(".lastUpdated") || file.name == "_remote.repositories") {
+                file.readLines().filterNot { it.startsWith("#") || it.isBlank() }.forEach { log("      $it") }
+            }
+            if (file.name.startsWith("enforcer-api-") && file.name.endsWith(".jar")) {
+                val entries = runCatching {
+                    java.util.zip.ZipFile(file).use { zip ->
+                        zip.entries().asSequence().count { it.name.contains("EnforcerRuleError") }
+                    }
+                }
+                log("      EnforcerRuleError entries=${entries.getOrElse { "ZIP ERROR: $it" }}")
+            }
+        }
+    }
+}
+
 data class CrossVersionTest(val mavenVersion: Provider<String>, val enforcerVersion: Provider<String>)
 
 val crossVersionTests = listOf(libs.versions.mavenMin, libs.versions.mavenMax)
@@ -74,6 +117,13 @@ val funcTestTasks = crossVersionTests
             // same-machine rebuilds. Cross-machine cache hits may still miss due
             // to absolute paths baked into the Maven define map.
             outputs.cacheIf("inputs fully tracked with relative path sensitivity") { true }
+
+            // TEMPORARY DIAGNOSTIC - remove with dumpInvokerRepoState above.
+            // The 'after' dump runs before the exit-code assertion added by
+            // importMavenInvokerTestResults, so it is reached on a failing run too.
+            val invokerRepo = m2Repository.map { it.dir("repository").asFile }
+            doFirst("dump invoker repo state before") { dumpInvokerRepoState("$taskName BEFORE", invokerRepo.get()) }
+            doLast("dump invoker repo state after") { dumpInvokerRepoState("$taskName AFTER", invokerRepo.get()) }
 
             mavenDir = maven.mavenHome(mavenVersion)
             goals(setOf("verify"))

--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -10,55 +10,25 @@ plugins {
 // TODO: fix duplication (see publishing-conventions)
 val m2Repository: Provider<Directory> = rootProject.layout.buildDirectory.dir("m2")
 
+// Maven downloads into this repository, and Gradle does not track what it writes there:
+// the publish task only ever removes its own outputs, so third-party artifacts survive
+// into the next build. In a reused CI workspace that is forever - which is how a
+// truncated enforcer-api jar kept every 'success' scenario failing for days, on a branch
+// whose sources were fine. Wiping it before anything publishes into it makes every build
+// start from the state a fresh workspace would have.
+val cleanInvokerLocalRepo = tasks.register<Delete>("cleanInvokerLocalRepo") {
+    description = "Deletes the Maven Invoker's local repository so no build inherits another build's artifacts"
+    delete(m2Repository)
+}
+
 // ProjectDependency.getDependencyProject() was removed in Gradle 9, resolve the project by its path instead
 val publishEnforcerRuleTask: Task? = project(projects.restrictImportsEnforcerRule.path)
     .tasks.findByName("publishMavenPublicationToLocalIntegrationTestsRepository")
 
+publishEnforcerRuleTask?.mustRunAfter(cleanInvokerLocalRepo)
+
 val functionalTest = tasks.register("functionalTest") {
     group = "verification"
-}
-
-// TEMPORARY DIAGNOSTIC - remove once the CI func-test failures are understood.
-//
-// Every invoker sub-build on CI (Jenkins and GitHub Actions alike) dies with
-// NoClassDefFoundError: org/apache/maven/enforcer/rule/api/EnforcerRuleError, while the
-// plugin realm lists enforcer-api-3.6.1.jar under this very repository. A URLClassLoader
-// silently skips a URL whose file is absent or unreadable, which produces exactly that
-// error - so this dumps what is actually on disk, from inside the CI container, both
-// before Maven starts and after it has failed.
-fun dumpInvokerRepoState(label: String, repoRoot: File) {
-    fun log(line: String) = println("[IT-DIAG] $line")
-
-    log("=== $label ===")
-    log("user.name=${System.getProperty("user.name")} user.home=${System.getProperty("user.home")}")
-    log("repoRoot=$repoRoot exists=${repoRoot.isDirectory} totalFiles=${repoRoot.walkTopDown().count { it.isFile }}")
-
-    listOf("org/apache/maven/enforcer", "org/apache/maven/plugins/maven-enforcer-plugin").forEach { subPath ->
-        val dir = repoRoot.resolve(subPath)
-        log("-- $subPath exists=${dir.isDirectory}")
-        if (!dir.isDirectory) return@forEach
-
-        dir.walkTopDown().filter { it.isFile }.sortedBy { it.path }.forEach { file ->
-            val sha1 = runCatching {
-                java.security.MessageDigest.getInstance("SHA-1")
-                    .digest(file.readBytes())
-                    .joinToString("") { byte -> "%02x".format(byte) }
-            }.getOrElse { "unreadable: $it" }
-            log("   ${file.length()}\t$sha1\treadable=${file.canRead()}\t${file.relativeTo(repoRoot)}")
-
-            if (file.name.endsWith(".lastUpdated") || file.name == "_remote.repositories") {
-                file.readLines().filterNot { it.startsWith("#") || it.isBlank() }.forEach { log("      $it") }
-            }
-            if (file.name.startsWith("enforcer-api-") && file.name.endsWith(".jar")) {
-                val entries = runCatching {
-                    java.util.zip.ZipFile(file).use { zip ->
-                        zip.entries().asSequence().count { it.name.contains("EnforcerRuleError") }
-                    }
-                }
-                log("      EnforcerRuleError entries=${entries.getOrElse { "ZIP ERROR: $it" }}")
-            }
-        }
-    }
 }
 
 data class CrossVersionTest(val mavenVersion: Provider<String>, val enforcerVersion: Provider<String>)
@@ -88,7 +58,7 @@ val funcTestTasks = crossVersionTests
             group = "verification"
             notCompatibleWithConfigurationCache("Inherently not")
 
-            dependsOn(downloadTask)
+            dependsOn(downloadTask, cleanInvokerLocalRepo)
 
             val mavenExecTask = this
 
@@ -118,18 +88,17 @@ val funcTestTasks = crossVersionTests
             // to absolute paths baked into the Maven define map.
             outputs.cacheIf("inputs fully tracked with relative path sensitivity") { true }
 
-            // TEMPORARY DIAGNOSTIC - remove with dumpInvokerRepoState above.
-            // The 'after' dump runs before the exit-code assertion added by
-            // importMavenInvokerTestResults, so it is reached on a failing run too.
-            val invokerRepo = m2Repository.map { it.dir("repository").asFile }
-            doFirst("dump invoker repo state before") { dumpInvokerRepoState("$taskName BEFORE", invokerRepo.get()) }
-            doLast("dump invoker repo state after") { dumpInvokerRepoState("$taskName AFTER", invokerRepo.get()) }
-
             mavenDir = maven.mavenHome(mavenVersion)
             goals(setOf("verify"))
             options.showVersion(true)
             define(
                 mapOf(
+                    // Without this the outer Maven resolves into ~/.m2, which on the CI
+                    // agent is a bind mount shared live with every concurrently running
+                    // build - and invoker-settings.xml then exposes that directory to all
+                    // 16 invoker JVMs as the 'local.central' repository. Pointing it at the
+                    // project-local repository keeps the integration tests off it entirely.
+                    "maven.repo.local" to m2Repository.get().dir("repository").asFile.absolutePath,
                     "revision" to project.version.toString(),
                     "fromGradle.test-id" to "maven.invoker.it.maven_$safeMavenVersion.enforcer_$safeEnforcerVersion",
                     "fromGradle.output-dir" to taskName,


### PR DESCRIPTION
Backports #290 to `develop`, which is one of the branches still failing.

## Why six commits and not four

#290's first commit edits `MavenInvokerTestReporting.kt`, which only exists because of
#287 — and `develop` does not have #287. So the two commits from #287 come along as a
prerequisite; without them the reporting fix has nothing to apply to and the later commits
conflict.

Everything cherry-picked cleanly: `develop` has not touched the maven-it module since the
merge base (`1ae70d9`), and #287 adds no new build dependencies. The affected paths on this
branch are now **byte-identical to `master`**, so the two branches will not diverge here
again.

## What this fixes on develop

`develop` has failed nine builds in a row with every `success` scenario failing and every
`fail-*` scenario passing vacuously:

```
java.lang.NoClassDefFoundError: org/apache/maven/enforcer/rule/api/EnforcerRuleError
```

A truncated `enforcer-api` jar was stuck in the branch's long-lived Jenkins workspace,
where nothing ever rechecked it — see #290 for the full analysis. The first build carrying
these commits wipes that repository, so `develop` heals without any manual workspace
surgery.

It also brings the run-time improvements measured in #290, which halved `functionalTest`
on the Jenkins agent (371s → 185s) by removing the contention on a single shared local
repository.

## Verification

Built from a cold repository on this branch: `functionalTest quickCheck build-logic:check
--no-build-cache`, all four legs `Passed: 31, Failed: 0`, `parallelThreads 16` (1C).
