### PR TITLE
Do not write a local build cache on CI

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,7 +35,11 @@ develocity {
 
 buildCache {
     local {
-        isEnabled = true
+        // Off on CI, where it is only ever a liability: the remote cache already serves
+        // every hit, but the local one still grows - it reached 339MB - and the Jenkins
+        // pipeline copies the whole Gradle home in and out of every build, so that growth
+        // is paid for on both legs of the copy, every time.
+        isEnabled = !isCI
     }
 
     remote(develocity.buildCache) {


### PR DESCRIPTION
Follow-up to #292, which is closed — see there for why per-executor isolation was
abandoned.

## The measurement

Restoring the Gradle cache from the host costs 189–399s per build, **30–47% of the total**,
and on one build longer than the entire func-test suite:

| build | **Load Gradle Cache** | Quickcheck | Unit | Func-tests | total |
| --- | --- | --- | --- | --- | --- |
| `master` #6 | **189s** | 47s | 15s | 256s | 625s |
| `PR-290` #5 | **249s** | 50s | 12s | 189s | 557s |
| `PR-288` #1 | **399s** | 138s | 20s | 220s | 842s |

It copies 7.1GB, and a large part of that is dead weight.

## Why the cache only grows

`store-gradle-cache.sh` uses `cp -au` — it can only *add* files, never remove them. Gradle's
own cache cleanup runs against `GRADLE_USER_HOME`, which is the throwaway container copy, so
its evictions are discarded with the container and never reach the host. The host cache is
append-only by construction:

```
1,3G  caches/9.7.0          current
918M  caches/8.13           dead - nothing tests it
764M  caches/8.10.2         dead
632M  caches/8.14.3         dead - the matrix moved to 8.14.5
783M  caches/modules-2      the part actually worth caching
339M  caches/build-cache-1  redundant with the Develocity remote cache
148M  caches/p2-data        needed (spotless groovy-eclipse)
1,5G  jdks
883M  wrapper
```

2.3GB is caches for Gradle versions nothing has tested since the TestKit matrix became
`["7.6.6", "8.14.5", GradleVersion.current().version]`.

## This change

One line: the local build cache is off on CI. The remote cache already serves every hit
there, so the local one is pure growth — and growth that gets copied in *and* out on every
build.

## The other 2.6GB is a host action

```sh
cd /home/jenkins/caches/restrict-imports/.gradle/caches
rm -rf 8.10.2 8.13 8.14.3 build-cache-1
```

All four are regenerated if ever needed. Together with this commit that should take the
restore from ~7.1GB to ~4.5GB, cutting roughly a third off the stage — worth re-measuring
afterwards from the `Load Gradle Cache from host` stage timing.

## Not fixed

The cache is still append-only, so the dead version caches will accumulate again the next
time the TestKit matrix moves. A periodic prune, or the persistent Gradle home from #292
(which would let Gradle's own cleanup work), is the real fix. This is the cheap part.
