### PR TITLE
Associate the build-logic build with the Develocity project

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -19,6 +19,10 @@ val isCI = System.getenv("CI") != null
 
 develocity {
     server = "https://community.develocity.cloud"
+    // Must match the projectId of the main build: this is a separate build, so it needs its own
+    // project association. Without it the instance treats its build cache requests as having no
+    // associated project, which credentials that are scoped to the project may not read.
+    projectId = "skuzzle"
 }
 
 buildCache {


### PR DESCRIPTION
Every GitHub Actions build has been logging a single remote build cache error and then giving up on the cache for the rest of the run:

```
> Configure project :build-logic
Could not load entry eedd05d250b3aca05f8e06f113d6be62 from remote build cache:
Loading entry from 'https://community.develocity.cloud/cache/eedd05d2…' response status 403: Forbidden
…
The remote build cache was disabled during the build due to errors.
```

Always the same entry, always at the same point, in all five workflows including `dependency-submission`.

`build-logic/settings.gradle.kts` set `server` but not `projectId`, so the included plugin build's cache requests carried no project association. [Project-level access control](https://docs.develocity.ai/2026.2/administration/access-control/project-level-access-control/) isolates cache entries by project, and authorisation is evaluated on the request rather than on the entry — a credential scoped to the `skuzzle` project and lacking *Access all data without an associated project* is refused before the entry is looked up. Probing the endpoint with a deliberately nonexistent key shows it plainly: the short-lived token gets a 403, the long-lived key a 404.

That also explains why Jenkins was fine. The Jenkinsfile hands Gradle the long-lived access key, whose user holds that permission. The workflows use `gradle/actions`' `develocity-access-key` input, which mints a short-lived token that does not. Same secret, different credential on the wire.

The main build was unaffected throughout: its entries are project-associated and read fine, which is why reads worked right up until `build-logic` was configured.

### How it got here

50b63c2 (#284) replaced the self-hosted `build-cache.taddiken.net` cache with the Develocity one. Before it, both builds shared a single settings script — the one whose comment read *"kind of a hack to reuse the build cache configuration for both the included plugin build as well as the main build"*. That commit deleted the shared script and duplicated the configuration into each settings file, but added `projectId` to the main build only. The comment added here is there to keep the two from drifting apart again.

### Note

`origin/develop` has the same gap (b296cd2 is the develop-side copy of the onboarding commit). A separate PR follows for it.