### PR TITLE
Associate the build-logic build with the Develocity project

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -19,6 +19,10 @@ val isCI = System.getenv("CI") != null
 
 develocity {
     server = "https://community.develocity.cloud"
+    // Must match the projectId of the main build: this is a separate build, so it needs its own
+    // project association. Without it the instance treats its build cache requests as having no
+    // associated project, which credentials that are scoped to the project may not read.
+    projectId = "skuzzle"
 }
 
 buildCache {


### PR DESCRIPTION
Develop-side counterpart of #295, where the full diagnosis lives. b296cd2 is the develop copy of the onboarding commit and carries the same gap.

`build-logic/settings.gradle.kts` set `server` but not `projectId`, so the included plugin build's remote build cache requests carried no project association. Develocity evaluates authorisation on the request rather than on the entry, so the short-lived token that `gradle/actions` mints — scoped to the `skuzzle` project, without *Access all data without an associated project* — was refused with a 403 on the first cache read of the build-logic build, and Gradle then disabled the remote cache for the rest of the run. Jenkins was unaffected because it hands Gradle the long-lived access key, whose user holds that permission.

Verified on the master-side branch: before the change every workflow run logged the 403 and *"The remote build cache was disabled during the build due to errors."*; after it, all four runs are clean and the cache stays enabled.