### PR TITLE
Verify checksums where the artifacts are actually downloaded

### DIFF
--- a/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
+++ b/restrict-imports-enforcer-rule-maven-it/restrict-imports-enforcer-rule-maven-it.gradle.kts
@@ -100,6 +100,7 @@ val funcTestTasks = crossVersionTests
             mavenDir = maven.mavenHome(mavenVersion)
             goals(setOf("verify"))
             options.showVersion(true)
+            options.strictChecksums(true)
             define(
                 mapOf(
                     // Without this the outer Maven resolves into ~/.m2, which on the CI


### PR DESCRIPTION
`funcTestMaven_3_8_1_enforcer_3_6_1` has been failing on Jenkins since the invoker-repository
fixes landed — [develop #13](https://community.develocity.cloud/s/plyy74ttvpyx4),
[#14](https://community.develocity.cloud/s/75aplbpsbzovq),
[#15](https://community.develocity.cloud/s/igdsppb4kflum) and
[`fix-build-cache`](https://community.develocity.cloud/s/i7d2hzuibsqyi), every one of them the
same shape: `funcTestMaven_3_8_1_enforcer_3_2_1` passes 31/31 while the `3_6_1` leg fails
exactly 18 of 31 — every scenario expecting a *successful* build, with the 13 expecting a
failure passing vacuously. That is what an enforcer plugin that dies before the rule runs
looks like. It is not the code: the same commit passes on GitHub Actions and, for
`ebd99b7f`, passed in the PR-295 workspace while failing in the `fix-build-cache` one on the
same agent at the same minute.

## Why the existing checksum policy never fired

c891644 put `<checksumPolicy>fail</checksumPolicy>` on both repositories in
`invoker-settings.xml`, on exactly the right reasoning — a truncated artifact accepted with
nothing but a warning is what surfaces much later as a `NoClassDefFoundError` from inside a
forked build. But that file governs the *forked scenario builds*, and the artifacts they need
never arrive there by download.

maven-invoker-plugin's `install` goal resolves the three `extraArtifacts` —
`maven-enforcer-plugin`, `enforcer-api`, `enforcer-rules` — through the **outer** Maven into
`build/m2/repository`, then copies them into the leg's repository. A copy consults no checksum
policy, and it does not even carry the `.sha1` that would let one be. After a cold run:

```
build/m2/repository/.../enforcer-api-3.6.1.jar   +  enforcer-api-3.6.1.jar.sha1
build/m2-<task>/repository/.../enforcer-api-3.6.1.jar        (no .sha1)
```

So the outer Maven is the only place the bytes can still be checked, and it was running on
Maven's default `warn`. This gives it `-C`.

## Why it matters more here than usual

Nothing wipes `build/m2/repository`. c69ddb7 gave each cross-version leg a repository it wipes
per build, but the directory those legs *copy from* is the outer Maven's own local repository —
also the publication target — and it lives in the workspace Jenkins reuses. One truncated jar
landing there is kept for good, and every `success` scenario of the matching leg fails from
then on.

## Verification

- `--strict-checksums` confirmed on the outer `mvn` command line.
- Against a **cold** `build/m2/repository`, which is the case that matters since `-C` also
  fails on *missing* checksums: 193 artifacts downloaded from Central, no complaint.
- All four legs `Passed: 31, Failed: 0` — [scan](https://community.develocity.cloud/s/52oay5u3o663i).

## Not covered by this PR

This guards future downloads only. The `develop` and `fix-build-cache` Jenkins workspaces still
hold the bad artifact and need `rm -rf <workspace>/build/m2` to go green.

The exception itself is still inferred rather than read: Develocity 2026.2.4 has no build-log
API, so the per-scenario `build.log` was not reachable.