### PR TITLE
Run quickCheck with the configuration cache on CI

### DIFF
--- a/.github/workflows/quick-check.yml
+++ b/.github/workflows/quick-check.yml
@@ -17,5 +17,6 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
         with:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       - name: Build with Gradle
-        run: ./gradlew quickCheck
+        run: ./gradlew quickCheck --configuration-cache

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .project
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+*.hprof
 target
 build
 out

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
         stage('Quickcheck') {
             steps {
                 withGradle {
-                    sh './gradlew quickCheck'
+                    sh './gradlew quickCheck --configuration-cache'
                 }
             }
         }

--- a/build-logic/conventions/src/main/kotlin/ProjectExtensions.kt
+++ b/build-logic/conventions/src/main/kotlin/ProjectExtensions.kt
@@ -3,18 +3,6 @@ import org.gradle.kotlin.dsl.the
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
 
-val Project.isSnapshot: Boolean
-    get() = (project.version as String).contains("SNAPSHOT")
-
-val Project.isCI: Boolean
-    get() = !System.getenv("CI").isNullOrEmpty()
-
-val Project.isJenkins: Boolean
-    get() = !System.getenv("JENKINS_URL").isNullOrEmpty()
-
-val Project.isGhActions: Boolean
-    get() =!System.getenv("GITHUB_ACTIONS").isNullOrEmpty()
-
 fun Project.requiredVersionFromLibs(name: String) =
     libsVersionCatalog.findVersion(name).get().requiredVersion
 

--- a/build-logic/conventions/src/main/kotlin/build-logic.publishing-conventions.gradle.kts
+++ b/build-logic/conventions/src/main/kotlin/build-logic.publishing-conventions.gradle.kts
@@ -23,8 +23,10 @@ tasks.withType<Jar>().configureEach {
     }
 }
 
+val runSigning = providers.environmentVariable("JENKINS_URL").map { it.isNotEmpty() }.orElse(false)
+
 tasks.withType<Sign>().configureEach {
-    onlyIf("Run on Jenkins, but not GitHub") { project.isJenkins }
+    enabled = runSigning.get()
 }
 
 signing {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@ org.gradle.caching=true
 org.gradle.parallel=true
 #org.gradle.configuration-cache=true
 org.gradle.java.installations.fromEnv=JDK_1_8,JDK8,JDK9,JDK17
+
+org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError


### PR DESCRIPTION
Opts `quickCheck` into the configuration cache on CI, as a first step towards enabling it for the whole build.

## Why

Measured on a warm `quickCheck`, configuration was **2140ms of a 2649ms build (81%)**. Execution was only 248ms, and the cacheable tasks in that graph already hit at **100%** — so configuration is where the remaining time in this task actually goes.

Reusing the configuration cache:

| | before | after | |
|---|---|---|---|
| Cold daemon | 7.66s | **4.78s** | −38% |
| Warm daemon | 2.84s | **2.61s** | −8% |

The cold-daemon number is the common case on CI, and locally the daemon was going cold far more often than it should (see the metaspace commit).

## What was in the way

Exactly one thing: the `onlyIf` spec on `Sign` tasks is evaluated at execution time, where touching `Task.project` is unsupported with the configuration cache. It now decides at configuration time via `enabled`, reading `JENKINS_URL` through `providers` so the value is registered as a configuration cache input and the entry invalidates correctly when the build moves between Jenkins and GitHub.

Passing that provider to an `onlyIf` spec instead does *not* work — the lambda then captures the script object, which cannot be serialized either.

## Why not enable it globally

`org.gradle.configuration-cache` stays commented out: tasks outside the `quickCheck` graph are still incompatible. The four `MavenExec` cross-version tasks in `restrict-imports-enforcer-rule-maven-it` are already annotated `notCompatibleWithConfigurationCache`, so `check` discards the entry but still succeeds.

## Also here

**Daemon metaspace.** The daemon ran on Gradle's defaults and kept expiring with *"running out of JVM Metaspace"*, eventually dying with an `OutOfMemoryError` that dropped a 410MB heap dump into the repo root. Spotless loads the Groovy-Eclipse formatter through OSGi, which is metaspace hungry. The visible symptom was an intermittent `spotlessGroovyCheck` failure on `Jenkinsfile`/`JenkinsfileRelease` with `NoClassDefFoundError: Could not initialize class GrEclipseFormatterStepImpl`, reproducing only on a long-lived daemon. With the raised limit, eight consecutive `quickCheck` runs share one surviving daemon.

**Dead code.** `Project.isJenkins` lost its last caller here; `isSnapshot`, `isCI` and `isGhActions` already had none.

## Before merging

⚠️ **GitHub Actions needs a `GRADLE_ENCRYPTION_KEY` repository secret** (`openssl rand -base64 16`). Without it `gradle/actions/setup-gradle` neither saves nor restores configuration-cache data, so every run would store a fresh entry and reuse nothing — the workflow still passes, it just gains nothing. Jenkins needs no such setup: the entry lives in the workspace, which is reused across builds.

## Verification

Run against this branch on top of `develop`:

- `quickCheck` stores its entry, then reuses it on subsequent runs — with signing both enabled (`JENKINS_URL` set) and disabled, zero configuration cache problems in both.
- Same store-then-reuse confirmed from a fresh clone, i.e. what CI does.
- `quickCheck` and `build-logic:check` pass.
- Build cache health unchanged: 100% hit rate, 0 misses.
